### PR TITLE
fix(frontend,api): fix UX bugs, extract shared utils, centralize API error handling

### DIFF
--- a/api/src/__tests__/error-handler.test.ts
+++ b/api/src/__tests__/error-handler.test.ts
@@ -1,0 +1,70 @@
+import {describe, it, expect} from 'bun:test';
+import {Hono} from 'hono';
+import {withErrorHandler} from '../error-handler';
+
+describe('withErrorHandler', () => {
+	it('returns handler result when no error', async () => {
+		const app = new Hono();
+		app.get(
+			'/ok',
+			withErrorHandler(async (c) => c.json({ok: true})),
+		);
+		const res = await app.request('/ok');
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {ok: boolean};
+		expect(body.ok).toBe(true);
+	});
+
+	it('returns 500 with real error message on thrown Error', async () => {
+		const app = new Hono();
+		app.get(
+			'/fail',
+			withErrorHandler(async () => {
+				throw new Error('storage exploded');
+			}),
+		);
+		const res = await app.request('/fail');
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as {error: string};
+		expect(body.error).toBe('storage exploded');
+	});
+
+	it('returns 500 with "unknown error" for non-Error throws', async () => {
+		const app = new Hono();
+		app.get(
+			'/fail-string',
+			withErrorHandler(async () => {
+				// eslint-disable-next-line @typescript-eslint/only-throw-error
+				throw 'oops';
+			}),
+		);
+		const res = await app.request('/fail-string');
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as {error: string};
+		expect(body.error).toBe('unknown error');
+	});
+
+	it('passes through 400 responses without catching', async () => {
+		const app = new Hono();
+		app.get(
+			'/bad',
+			withErrorHandler(async (c) => c.json({error: 'bad input'}, 400)),
+		);
+		const res = await app.request('/bad');
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as {error: string};
+		expect(body.error).toBe('bad input');
+	});
+
+	it('passes through 200 responses with correct body', async () => {
+		const app = new Hono();
+		app.get(
+			'/data',
+			withErrorHandler(async (c) => c.json({value: 42})),
+		);
+		const res = await app.request('/data');
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {value: number};
+		expect(body.value).toBe(42);
+	});
+});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -2,6 +2,7 @@ import {Hono} from 'hono';
 import {Zip, ZipPassThrough} from 'fflate';
 import type {Storage} from './storage';
 import {invalidate, invalidateWithAncestors} from './count-cache';
+import {withErrorHandler} from './error-handler';
 
 function buildZipStream(
 	storage: Storage,
@@ -49,68 +50,54 @@ function buildZipStream(
 export function createApp(storage: Storage): Hono {
 	const app = new Hono();
 
-	app.get('/api/buckets', async (c) => {
-		try {
+	app.get(
+		'/api/buckets',
+		withErrorHandler(async (c) => {
 			const buckets = await storage.listBuckets();
 			return c.json({buckets});
-		} catch (err) {
-			process.stderr.write(
-				`GET /api/buckets error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to list buckets'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.get('/api/buckets/:bucket/objects', async (c) => {
-		const {bucket} = c.req.param();
-		const prefix = c.req.query('prefix') ?? '';
-		const offset = parseInt(c.req.query('offset') ?? '0', 10);
-		const limit = parseInt(c.req.query('limit') ?? '100', 10);
-		try {
+	app.get(
+		'/api/buckets/:bucket/objects',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const prefix = c.req.query('prefix') ?? '';
+			const offset = parseInt(c.req.query('offset') ?? '0', 10);
+			const limit = parseInt(c.req.query('limit') ?? '100', 10);
 			const {objects, totalCount} = await storage.listObjects(bucket, prefix, offset, limit);
 			return c.json({objects, totalCount});
-		} catch (err) {
-			process.stderr.write(
-				`GET /api/buckets/${bucket}/objects error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to list objects'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.get('/api/buckets/:bucket/objects-all', async (c) => {
-		const {bucket} = c.req.param();
-		const prefix = c.req.query('prefix') ?? '';
-		try {
+	app.get(
+		'/api/buckets/:bucket/objects-all',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const prefix = c.req.query('prefix') ?? '';
 			const keys = await storage.listAllObjects(bucket, prefix);
 			return c.json({keys});
-		} catch (err) {
-			process.stderr.write(
-				`GET /api/buckets/${bucket}/objects-all error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to list objects'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.get('/api/buckets/:bucket/folder-size', async (c) => {
-		const {bucket} = c.req.param();
-		const prefix = c.req.query('prefix') ?? '';
-		try {
+	app.get(
+		'/api/buckets/:bucket/folder-size',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const prefix = c.req.query('prefix') ?? '';
 			const size = await storage.getFolderSize(bucket, prefix);
 			return c.json({size});
-		} catch (err) {
-			const message = err instanceof Error ? err.message : 'Unknown error';
-			process.stderr.write(`GET /api/buckets/${bucket}/folder-size error: ${message}\n`);
-			return c.json({error: message}, 500);
-		}
-	});
+		}),
+	);
 
-	app.get('/api/buckets/:bucket/object', async (c) => {
-		const {bucket} = c.req.param();
-		const key = c.req.query('key');
-		if (key === undefined || key === '') {
-			return c.json({error: 'Missing key parameter'}, 400);
-		}
-		try {
+	app.get(
+		'/api/buckets/:bucket/object',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const key = c.req.query('key');
+			if (key === undefined || key === '') {
+				return c.json({error: 'Missing key parameter'}, 400);
+			}
 			const {body, contentType, contentLength} = await storage.getObjectStream(bucket, key);
 			const headers = new Headers();
 			if (contentType !== undefined) {
@@ -120,22 +107,18 @@ export function createApp(storage: Storage): Hono {
 				headers.set('Content-Length', contentLength.toString());
 			}
 			return new Response(body, {headers});
-		} catch (err) {
-			process.stderr.write(
-				`GET /api/buckets/${bucket}/object error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to stream object'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.get('/api/buckets/:bucket/download', async (c) => {
-		const {bucket} = c.req.param();
-		const key = c.req.query('key');
-		if (key === undefined || key === '') {
-			return c.json({error: 'Missing key parameter'}, 400);
-		}
-		const filename = key.split('/').pop() ?? key;
-		try {
+	app.get(
+		'/api/buckets/:bucket/download',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const key = c.req.query('key');
+			if (key === undefined || key === '') {
+				return c.json({error: 'Missing key parameter'}, 400);
+			}
+			const filename = key.split('/').pop() ?? key;
 			const {body, contentType, contentLength} = await storage.getObjectStream(bucket, key);
 			const headers = new Headers();
 			headers.set(
@@ -149,28 +132,24 @@ export function createApp(storage: Storage): Hono {
 				headers.set('Content-Length', contentLength.toString());
 			}
 			return new Response(body, {headers});
-		} catch (err) {
-			process.stderr.write(
-				`GET /api/buckets/${bucket}/download error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to download object'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.post('/api/buckets/:bucket/upload', async (c) => {
-		const {bucket} = c.req.param();
-		const prefix = c.req.query('prefix') ?? '';
-		let formData: FormData;
-		try {
-			formData = await c.req.formData();
-		} catch {
-			return c.json({error: 'Invalid form data'}, 400);
-		}
-		const files = formData.getAll('file');
-		if (files.length === 0) {
-			return c.json({error: 'No files provided'}, 400);
-		}
-		try {
+	app.post(
+		'/api/buckets/:bucket/upload',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const prefix = c.req.query('prefix') ?? '';
+			let formData: FormData;
+			try {
+				formData = await c.req.formData();
+			} catch {
+				return c.json({error: 'Invalid form data'}, 400);
+			}
+			const files = formData.getAll('file');
+			if (files.length === 0) {
+				return c.json({error: 'No files provided'}, 400);
+			}
 			for (const file of files) {
 				if (!(file instanceof File)) {
 					continue;
@@ -182,60 +161,48 @@ export function createApp(storage: Storage): Hono {
 			}
 			invalidate(bucket, prefix);
 			return c.json({ok: true});
-		} catch (err) {
-			process.stderr.write(
-				`POST /api/buckets/${bucket}/upload error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Upload failed'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.delete('/api/buckets/:bucket/object', async (c) => {
-		const {bucket} = c.req.param();
-		const key = c.req.query('key');
-		if (key === undefined || key === '') {
-			return c.json({error: 'Missing key parameter'}, 400);
-		}
-		try {
+	app.delete(
+		'/api/buckets/:bucket/object',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const key = c.req.query('key');
+			if (key === undefined || key === '') {
+				return c.json({error: 'Missing key parameter'}, 400);
+			}
 			await storage.deleteObject(bucket, key);
 			const lastSlash = key.lastIndexOf('/');
 			const parentPrefix = lastSlash === -1 ? '' : key.slice(0, lastSlash + 1);
 			invalidate(bucket, parentPrefix);
 			return c.json({ok: true});
-		} catch (err) {
-			process.stderr.write(
-				`DELETE /api/buckets/${bucket}/object error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to delete object'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.delete('/api/buckets/:bucket/folder', async (c) => {
-		const {bucket} = c.req.param();
-		const prefix = c.req.query('prefix');
-		if (prefix === undefined || prefix === '') {
-			return c.json({error: 'Missing prefix parameter'}, 400);
-		}
-		try {
+	app.delete(
+		'/api/buckets/:bucket/folder',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const prefix = c.req.query('prefix');
+			if (prefix === undefined || prefix === '') {
+				return c.json({error: 'Missing prefix parameter'}, 400);
+			}
 			const keys = await storage.listAllObjects(bucket, prefix);
 			if (keys.length > 0) {
 				await storage.deleteObjects(bucket, keys);
 			}
 			invalidateWithAncestors(bucket, prefix);
 			return c.json({ok: true});
-		} catch (err) {
-			process.stderr.write(
-				`DELETE /api/buckets/${bucket}/folder error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to delete folder'}, 500);
-		}
-	});
+		}),
+	);
 
-	app.get('/api/buckets/:bucket/download-folder', async (c) => {
-		const {bucket} = c.req.param();
-		const prefix = c.req.query('prefix') ?? '';
-		const folderName = prefix.split('/').filter(Boolean).pop() ?? bucket;
-		try {
+	app.get(
+		'/api/buckets/:bucket/download-folder',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const prefix = c.req.query('prefix') ?? '';
+			const folderName = prefix.split('/').filter(Boolean).pop() ?? bucket;
 			const keys = await storage.listAllObjects(bucket, prefix);
 			const zipStream = buildZipStream(storage, bucket, keys, prefix);
 			const headers = new Headers();
@@ -245,13 +212,8 @@ export function createApp(storage: Storage): Hono {
 				`attachment; filename*=UTF-8''${encodeURIComponent(folderName)}.zip`,
 			);
 			return new Response(zipStream, {headers});
-		} catch (err) {
-			process.stderr.write(
-				`GET /api/buckets/${bucket}/download-folder error: ${err instanceof Error ? err.message : 'unknown error'}\n`,
-			);
-			return c.json({error: 'Failed to create ZIP'}, 500);
-		}
-	});
+		}),
+	);
 
 	return app;
 }

--- a/api/src/error-handler.ts
+++ b/api/src/error-handler.ts
@@ -1,0 +1,15 @@
+import type {Context} from 'hono';
+
+export const withErrorHandler = (
+	handler: (c: Context) => Promise<Response>,
+): ((c: Context) => Promise<Response>) => {
+	return async (c: Context) => {
+		try {
+			return await handler(c);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'unknown error';
+			process.stderr.write(`${c.req.method} ${c.req.path} error: ${message}\n`);
+			return c.json({error: message}, 500);
+		}
+	};
+};

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "react": "^19",
         "react-dom": "^19",
         "react-router-dom": "^7",
+        "streamsaver": "^2.0.6",
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6",
@@ -44,6 +45,7 @@
         "@testing-library/user-event": "^14",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/streamsaver": "^2.0.5",
         "@vitejs/plugin-react": "^4",
         "jsdom": "^25",
         "msw": "^2",
@@ -515,6 +517,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
+    "@types/streamsaver": ["@types/streamsaver@2.0.5", "", {}, "sha512-93o0zjV8swEhR2YI57h/2ytbJF8bJh7sI9GNB02TLJHdM4fWDxZuChwfWhyD8vt2ub4kw4rsfZ0C0yAUX+3gcg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.1", "@typescript-eslint/type-utils": "8.58.1", "@typescript-eslint/utils": "8.58.1", "@typescript-eslint/visitor-keys": "8.58.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ=="],
 
@@ -997,6 +1001,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "streamsaver": ["streamsaver@2.0.6", "", {}, "sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,19 +14,21 @@
 		"@tabler/icons-react": "^3.41.1",
 		"react": "^19",
 		"react-dom": "^19",
-		"react-router-dom": "^7"
+		"react-router-dom": "^7",
+		"streamsaver": "^2.0.6"
 	},
 	"devDependencies": {
-		"vite": "^6",
-		"@vitejs/plugin-react": "^4",
-		"vitest": "^3",
-		"jsdom": "^25",
+		"@testing-library/jest-dom": "^6",
 		"@testing-library/react": "^16",
 		"@testing-library/user-event": "^14",
-		"@testing-library/jest-dom": "^6",
+		"@types/react": "^19",
+		"@types/react-dom": "^19",
+		"@types/streamsaver": "^2.0.5",
+		"@vitejs/plugin-react": "^4",
+		"jsdom": "^25",
 		"msw": "^2",
 		"typescript": "^5",
-		"@types/react": "^19",
-		"@types/react-dom": "^19"
+		"vite": "^6",
+		"vitest": "^3"
 	}
 }

--- a/frontend/src/__tests__/ImagePreviewPage.test.tsx
+++ b/frontend/src/__tests__/ImagePreviewPage.test.tsx
@@ -127,4 +127,48 @@ describe('ImagePreviewPage', () => {
 			expect(screen.getByText('beach.jpg')).toBeInTheDocument();
 		});
 	});
+
+	it('folder entries in siblings are excluded from Prev/Next navigation', async () => {
+		const user = userEvent.setup();
+		const siblingsWithFolder: S3Object[] = [
+			{
+				key: 'photos/beach.jpg',
+				size: 204800,
+				lastModified: '2024-06-01T12:00:00.000Z',
+				isPrefix: false,
+			},
+			{key: 'photos/sub/', size: 0, lastModified: '', isPrefix: true},
+			{
+				key: 'photos/report.pdf',
+				size: 51200,
+				lastModified: '2024-06-02T09:00:00.000Z',
+				isPrefix: false,
+			},
+		];
+		renderPage('photos/beach.jpg', {siblings: siblingsWithFolder});
+		await user.click(screen.getByRole('button', {name: /next/i}));
+		await waitFor(() => {
+			expect(screen.getByText('report.pdf')).toBeInTheDocument();
+		});
+	});
+
+	it('Next not disabled for first file when only intervening sibling is a folder', () => {
+		const siblingsWithFolder: S3Object[] = [
+			{
+				key: 'photos/beach.jpg',
+				size: 204800,
+				lastModified: '2024-06-01T12:00:00.000Z',
+				isPrefix: false,
+			},
+			{key: 'photos/sub/', size: 0, lastModified: '', isPrefix: true},
+			{
+				key: 'photos/report.pdf',
+				size: 51200,
+				lastModified: '2024-06-02T09:00:00.000Z',
+				isPrefix: false,
+			},
+		];
+		renderPage('photos/beach.jpg', {siblings: siblingsWithFolder});
+		expect(screen.getByRole('button', {name: /next/i})).not.toBeDisabled();
+	});
 });

--- a/frontend/src/__tests__/ObjectBrowserPage.test.tsx
+++ b/frontend/src/__tests__/ObjectBrowserPage.test.tsx
@@ -5,8 +5,15 @@ import {MantineProvider} from '@mantine/core';
 import {Notifications} from '@mantine/notifications';
 import {http, HttpResponse} from 'msw';
 import {setupServer} from 'msw/node';
+import {vi} from 'vitest';
 import {ObjectBrowserPage} from '../pages/ObjectBrowserPage';
 import type {S3Object} from '@shared/types';
+
+vi.mock('streamsaver', () => ({
+	default: {
+		createWriteStream: vi.fn(() => new WritableStream()),
+	},
+}));
 
 const mockObjects: S3Object[] = [
 	{key: 'docs/', size: 0, lastModified: '', isPrefix: true},
@@ -178,6 +185,25 @@ describe('ObjectBrowserPage', () => {
 		await user.click(screen.getByText('docs/'));
 		await waitFor(() => {
 			expect(capturedUrl).toContain('offset=0');
+		});
+	});
+
+	it('clears stale objects when navigation to new prefix fails', async () => {
+		const user = userEvent.setup();
+		renderPage('/buckets/my-bucket');
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+
+		server.use(
+			http.get('/api/buckets/:bucket/objects', () => new HttpResponse(null, {status: 500})),
+		);
+
+		await user.click(screen.getByText('docs/'));
+
+		await waitFor(() => {
+			expect(screen.queryAllByText(/Failed to load objects/i).length).toBeGreaterThan(0);
+			expect(screen.queryByText('readme.txt')).not.toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/__tests__/breadcrumbs.test.ts
+++ b/frontend/src/__tests__/breadcrumbs.test.ts
@@ -1,0 +1,37 @@
+import {describe, it, expect} from 'vitest';
+import {buildBreadcrumbSegments} from '../utils/breadcrumbs';
+
+describe('buildBreadcrumbSegments', () => {
+	it('returns empty array for empty path', () => {
+		expect(buildBreadcrumbSegments('')).toEqual([]);
+	});
+
+	it('returns single segment with null prefix for single-part path', () => {
+		expect(buildBreadcrumbSegments('file.txt')).toEqual([{label: 'file.txt', prefix: null}]);
+	});
+
+	it('last segment has null prefix', () => {
+		const segments = buildBreadcrumbSegments('a/b/c');
+		expect(segments[segments.length - 1].prefix).toBeNull();
+	});
+
+	it('intermediate segments have correct prefix', () => {
+		const segments = buildBreadcrumbSegments('a/b/c');
+		expect(segments[0]).toEqual({label: 'a', prefix: 'a/'});
+		expect(segments[1]).toEqual({label: 'b', prefix: 'a/b/'});
+		expect(segments[2]).toEqual({label: 'c', prefix: null});
+	});
+
+	it('filters trailing slash (folder prefix)', () => {
+		const segments = buildBreadcrumbSegments('docs/');
+		expect(segments).toEqual([{label: 'docs', prefix: null}]);
+	});
+
+	it('handles two-part path', () => {
+		const segments = buildBreadcrumbSegments('photos/beach.jpg');
+		expect(segments).toEqual([
+			{label: 'photos', prefix: 'photos/'},
+			{label: 'beach.jpg', prefix: null},
+		]);
+	});
+});

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -1,0 +1,36 @@
+import {describe, it, expect} from 'vitest';
+import {formatSize, formatDate} from '../utils/format';
+
+describe('formatSize', () => {
+	it('formats bytes', () => {
+		expect(formatSize(500)).toBe('500 B');
+	});
+
+	it('formats KB', () => {
+		expect(formatSize(1536)).toBe('1.5 KB');
+	});
+
+	it('formats MB', () => {
+		expect(formatSize(1024 * 1024 * 2)).toBe('2.0 MB');
+	});
+
+	it('formats GB', () => {
+		expect(formatSize(1024 * 1024 * 1024 * 3)).toBe('3.0 GB');
+	});
+
+	it('formats 0 bytes', () => {
+		expect(formatSize(0)).toBe('0 B');
+	});
+});
+
+describe('formatDate', () => {
+	it('returns dash for empty string', () => {
+		expect(formatDate('')).toBe('—');
+	});
+
+	it('formats ISO date string', () => {
+		const result = formatDate('2024-01-01T00:00:00.000Z');
+		expect(result).not.toBe('—');
+		expect(result).toMatch(/2024/);
+	});
+});

--- a/frontend/src/pages/ImagePreviewPage.tsx
+++ b/frontend/src/pages/ImagePreviewPage.tsx
@@ -3,47 +3,11 @@ import {Anchor, Breadcrumbs, Button, Container, Group, Stack, Text} from '@manti
 import {IconPhoto, IconChevronLeft, IconChevronRight} from '@tabler/icons-react';
 import type {S3Object} from '@shared/types';
 import {isImageFile} from '../utils/imageUtils';
+import {formatSize, formatDate} from '../utils/format';
+import {buildBreadcrumbSegments} from '../utils/breadcrumbs';
 
 const objectUrl = (bucket: string, key: string): string =>
 	`/api/buckets/${encodeURIComponent(bucket)}/object?key=${encodeURIComponent(key)}`;
-
-const formatSize = (bytes: number): string => {
-	if (bytes < 1024) {
-		return `${bytes} B`;
-	}
-	if (bytes < 1024 * 1024) {
-		return `${(bytes / 1024).toFixed(1)} KB`;
-	}
-	if (bytes < 1024 * 1024 * 1024) {
-		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-	}
-	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-};
-
-const formatDate = (isoString: string): string => {
-	if (isoString === '') {
-		return '—';
-	}
-	return new Date(isoString).toLocaleString();
-};
-
-const buildBreadcrumbs = (bucket: string, key: string) => {
-	const parts = key.split('/').filter((p) => p.length > 0);
-	return [
-		{label: bucket, href: `/buckets/${encodeURIComponent(bucket)}`},
-		...parts.map((part, i) => {
-			const isLast = i === parts.length - 1;
-			if (isLast) {
-				return {label: part, href: null};
-			}
-			const prefix = `${parts.slice(0, i + 1).join('/')}/`;
-			return {
-				label: part,
-				href: `/buckets/${encodeURIComponent(bucket)}?prefix=${encodeURIComponent(prefix)}`,
-			};
-		}),
-	];
-};
 
 export const ImagePreviewPage = () => {
 	const {bucket} = useParams<{bucket: string}>();
@@ -53,7 +17,8 @@ export const ImagePreviewPage = () => {
 
 	const navigate = useNavigate();
 
-	const siblings: S3Object[] = (state as {siblings?: S3Object[]} | null)?.siblings ?? [];
+	const rawSiblings: S3Object[] = (state as {siblings?: S3Object[]} | null)?.siblings ?? [];
+	const siblings = rawSiblings.filter((obj) => !obj.isPrefix);
 	const currentIndex = siblings.findIndex((obj) => obj.key === key);
 	const currentFile = currentIndex !== -1 ? siblings[currentIndex] : undefined;
 	const hasSiblings = siblings.length > 0;
@@ -69,7 +34,17 @@ export const ImagePreviewPage = () => {
 		return null;
 	}
 
-	const crumbs = buildBreadcrumbs(bucket, key);
+	const segments = buildBreadcrumbSegments(key);
+	const crumbs = [
+		{label: bucket, href: `/buckets/${encodeURIComponent(bucket)}`},
+		...segments.map((seg) => ({
+			label: seg.label,
+			href:
+				seg.prefix !== null
+					? `/buckets/${encodeURIComponent(bucket)}?prefix=${encodeURIComponent(seg.prefix)}`
+					: null,
+		})),
+	];
 
 	return (
 		<>

--- a/frontend/src/pages/ObjectBrowserPage.tsx
+++ b/frontend/src/pages/ObjectBrowserPage.tsx
@@ -23,49 +23,12 @@ import {
 	IconTrash,
 	IconUpload,
 } from '@tabler/icons-react';
+import streamSaver from 'streamsaver';
 import type {S3Object} from '@shared/types';
 import {fetchFolderSize, fetchObjects} from '../api/client';
 import {PaginationControls} from '../components/Pagination';
-
-const triggerBlobDownload = (blob: Blob, filename: string): void => {
-	const url = URL.createObjectURL(blob);
-	const a = document.createElement('a');
-	a.href = url;
-	a.download = filename;
-	a.click();
-	URL.revokeObjectURL(url);
-};
-
-const buildBreadcrumbs = (bucket: string, prefix: string) => {
-	const parts = prefix.split('/').filter((p) => p.length > 0);
-	return [
-		{label: bucket, prefix: ''},
-		...parts.map((part, i) => ({
-			label: part,
-			prefix: `${parts.slice(0, i + 1).join('/')}/`,
-		})),
-	];
-};
-
-const formatSize = (bytes: number): string => {
-	if (bytes < 1024) {
-		return `${bytes} B`;
-	}
-	if (bytes < 1024 * 1024) {
-		return `${(bytes / 1024).toFixed(1)} KB`;
-	}
-	if (bytes < 1024 * 1024 * 1024) {
-		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-	}
-	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-};
-
-const formatDate = (isoString: string): string => {
-	if (isoString === '') {
-		return '—';
-	}
-	return new Date(isoString).toLocaleString();
-};
+import {formatSize, formatDate} from '../utils/format';
+import {buildBreadcrumbSegments} from '../utils/breadcrumbs';
 
 const downloadUrl = (bucket: string, key: string): string =>
 	`/api/buckets/${encodeURIComponent(bucket)}/download?key=${encodeURIComponent(key)}`;
@@ -112,6 +75,7 @@ export const ObjectBrowserPage = () => {
 			return;
 		}
 		let cancelled = false;
+		setObjects([]);
 		setLoading(true);
 		const offset = (page - 1) * pageSize;
 		void fetchObjects(bucket, prefix, offset, pageSize)
@@ -173,7 +137,10 @@ export const ObjectBrowserPage = () => {
 		}
 	};
 
-	const crumbs = buildBreadcrumbs(bucket, prefix);
+	const crumbs: Array<{label: string; prefix: string | null}> = [
+		{label: bucket, prefix: ''},
+		...buildBreadcrumbSegments(prefix),
+	];
 
 	const navigateTo = (newPrefix: string) => {
 		setSearchParams((prev) => {
@@ -215,8 +182,8 @@ export const ObjectBrowserPage = () => {
 			if (!res.ok || res.body === null) {
 				throw new Error(`Download failed: ${res.status}`);
 			}
-			const blob = await res.blob();
-			triggerBlobDownload(blob, `${folderName}.zip`);
+			const fileStream = streamSaver.createWriteStream(`${folderName}.zip`);
+			await res.body.pipeTo(fileStream);
 		} catch (err) {
 			notifications.show({
 				title: 'Failed to download folder',
@@ -363,17 +330,17 @@ export const ObjectBrowserPage = () => {
 						const isBucket = i === 0;
 						if (isLast && !isBucket) {
 							return (
-								<Text key={crumb.prefix} span fw={500}>
+								<Text key={crumb.label} span fw={500}>
 									{crumb.label}
 								</Text>
 							);
 						}
 						return (
 							<Anchor
-								key={crumb.prefix}
+								key={crumb.prefix ?? crumb.label}
 								component="button"
 								type="button"
-								onClick={() => navigateTo(crumb.prefix)}
+								onClick={() => navigateTo(crumb.prefix ?? '')}
 							>
 								{crumb.label}
 							</Anchor>

--- a/frontend/src/utils/breadcrumbs.ts
+++ b/frontend/src/utils/breadcrumbs.ts
@@ -1,0 +1,12 @@
+export interface BreadcrumbSegment {
+	label: string;
+	prefix: string | null;
+}
+
+export const buildBreadcrumbSegments = (path: string): BreadcrumbSegment[] => {
+	const parts = path.split('/').filter((p) => p.length > 0);
+	return parts.map((part, i) => ({
+		label: part,
+		prefix: i < parts.length - 1 ? `${parts.slice(0, i + 1).join('/')}/` : null,
+	}));
+};

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,19 @@
+export const formatSize = (bytes: number): string => {
+	if (bytes < 1024) {
+		return `${bytes} B`;
+	}
+	if (bytes < 1024 * 1024) {
+		return `${(bytes / 1024).toFixed(1)} KB`;
+	}
+	if (bytes < 1024 * 1024 * 1024) {
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	}
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+};
+
+export const formatDate = (isoString: string): string => {
+	if (isoString === '') {
+		return '—';
+	}
+	return new Date(isoString).toLocaleString();
+};


### PR DESCRIPTION
## Summary

- **Stale objects cleared on navigation failure** — `setObjects([])` before fetch so failed navigation shows empty table, not previous folder's files
- **Folder rows filtered from preview siblings** — `isPrefix: true` entries excluded so Prev/Next never lands on a folder placeholder
- **Streaming folder downloads** — replaced `await res.blob()` with `streamsaver` + `res.body.pipeTo()` to avoid buffering large ZIPs in memory
- **Shared format/breadcrumb utilities** — `formatSize`, `formatDate` extracted to `utils/format.ts`; `buildBreadcrumbSegments` to `utils/breadcrumbs.ts`; both pages import from there
- **Centralized API error handling** — `withErrorHandler` HOF in `api/src/error-handler.ts` wraps all 10 route handlers; real error messages returned in JSON responses

Closes #5

## Test plan

- [ ] All 171 tests pass (60 API + 111 frontend)
- [ ] Navigate into folder, go offline, verify stale files don't show on failed navigation
- [ ] Preview file in mixed folder (files + subfolders), verify Prev/Next skips subfolders
- [ ] Download large folder ZIP, verify no memory spike in browser
- [ ] Hit broken S3 config, verify real error message in JSON response and stderr log

🤖 Generated with [Claude Code](https://claude.com/claude-code)