### PR TITLE
feat: bucket list width alignment + enriched bucket metadata

### DIFF
--- a/api/src/__tests__/buckets.test.ts
+++ b/api/src/__tests__/buckets.test.ts
@@ -1,26 +1,89 @@
 import {describe, it, expect} from 'bun:test';
 import {createApp} from '../app';
 import {FakeStorage} from '../storage-fake';
-import type {Bucket} from '@shared/types';
+import type {Bucket, BucketStats} from '@shared/types';
 
 const fakeBuckets: Bucket[] = [
-	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z'},
-	{name: 'another-bucket', creationDate: '2024-02-01T00:00:00.000Z'},
+	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z', region: 'us-east-1'},
+	{name: 'another-bucket', creationDate: '2024-02-01T00:00:00.000Z', region: 'eu-west-1'},
 ];
 
 describe('GET /api/buckets', () => {
-	it('returns 200 with bucket list', async () => {
+	it('returns 200 with bucket list including region', async () => {
 		const app = createApp(new FakeStorage(fakeBuckets));
 		const res = await app.request('/api/buckets');
 
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {buckets: Bucket[]};
 		expect(body.buckets).toEqual(fakeBuckets);
+		expect(body.buckets.find((b) => b.name === 'my-bucket')?.region).toBe('us-east-1');
+		expect(body.buckets.find((b) => b.name === 'another-bucket')?.region).toBe('eu-west-1');
 	});
 
 	it('returns 500 when storage fails', async () => {
 		const app = createApp(new FakeStorage([], {fail: true}));
 		const res = await app.request('/api/buckets');
+
+		expect(res.status).toBe(500);
+	});
+});
+
+describe('GET /api/buckets/:bucket/stats', () => {
+	it('returns correct objectCount and totalSize', async () => {
+		const bucketName = 'my-bucket';
+		const storage = new FakeStorage(
+			fakeBuckets,
+			{},
+			{
+				[bucketName]: [
+					{key: 'file1.txt', size: 100, lastModified: '', isPrefix: false},
+					{key: 'file2.txt', size: 200, lastModified: '', isPrefix: false},
+				],
+			},
+		);
+		const app = createApp(storage);
+		const res = await app.request('/api/buckets/my-bucket/stats');
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as BucketStats;
+		expect(body.objectCount).toBe(2);
+		expect(body.totalSize).toBe(300);
+	});
+
+	it('returns zeros for empty bucket', async () => {
+		const app = createApp(new FakeStorage(fakeBuckets));
+		const res = await app.request('/api/buckets/my-bucket/stats');
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as BucketStats;
+		expect(body.objectCount).toBe(0);
+		expect(body.totalSize).toBe(0);
+	});
+
+	it('excludes prefix entries from stats', async () => {
+		const bucketName = 'my-bucket';
+		const storage = new FakeStorage(
+			fakeBuckets,
+			{},
+			{
+				[bucketName]: [
+					{key: 'folder/', size: 0, lastModified: '', isPrefix: true},
+					{key: 'folder/file.txt', size: 500, lastModified: '', isPrefix: false},
+				],
+			},
+		);
+		const app = createApp(storage);
+		const res = await app.request('/api/buckets/my-bucket/stats');
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as BucketStats;
+		expect(body.objectCount).toBe(1);
+		expect(body.totalSize).toBe(500);
+	});
+
+	it('returns 500 when storage fails', async () => {
+		const app = createApp(new FakeStorage(fakeBuckets, {fail: true}));
+		const res = await app.request('/api/buckets/my-bucket/stats');
 
 		expect(res.status).toBe(500);
 	});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -59,6 +59,15 @@ export function createApp(storage: Storage): Hono {
 	);
 
 	app.get(
+		'/api/buckets/:bucket/stats',
+		withErrorHandler(async (c) => {
+			const {bucket} = c.req.param();
+			const stats = await storage.getBucketStats(bucket);
+			return c.json(stats);
+		}),
+	);
+
+	app.get(
 		'/api/buckets/:bucket/objects',
 		withErrorHandler(async (c) => {
 			const {bucket} = c.req.param();

--- a/api/src/storage-fake.ts
+++ b/api/src/storage-fake.ts
@@ -1,4 +1,4 @@
-import type {Bucket, S3Object} from '@shared/types';
+import type {Bucket, BucketStats, S3Object} from '@shared/types';
 import type {ListObjectsResult, ObjectStream, Storage} from './storage';
 
 interface FakeStorageOptions {
@@ -104,6 +104,17 @@ export class FakeStorage implements Storage {
 		}
 		const existing = this.deletedKeys.get(bucket) ?? [];
 		this.deletedKeys.set(bucket, [...existing, ...keys]);
+	}
+
+	public async getBucketStats(name: string): Promise<BucketStats> {
+		if (this.options.fail === true) {
+			throw new Error('FakeStorage: forced failure');
+		}
+		const objects = (this.objectsByBucket[name] ?? []).filter((obj) => !obj.isPrefix);
+		return {
+			objectCount: objects.length,
+			totalSize: objects.reduce((sum, obj) => sum + obj.size, 0),
+		};
 	}
 
 	public async getObjectStream(_bucket: string, _key: string): Promise<ObjectStream> {

--- a/api/src/storage-real.ts
+++ b/api/src/storage-real.ts
@@ -8,7 +8,7 @@ import {
 } from '@aws-sdk/client-s3';
 import {Upload} from '@aws-sdk/lib-storage';
 
-import type {Bucket, S3Object} from '@shared/types';
+import type {Bucket, BucketStats, S3Object} from '@shared/types';
 import type {ListObjectsResult, ObjectStream, Storage} from './storage';
 import {getCount, setCount} from './count-cache';
 
@@ -24,7 +24,28 @@ export class S3Storage implements Storage {
 		return (result.Buckets ?? []).map((b) => ({
 			name: b.Name ?? '',
 			creationDate: b.CreationDate?.toISOString() ?? '',
+			region: b.BucketRegion ?? '',
 		}));
+	}
+
+	public async getBucketStats(name: string): Promise<BucketStats> {
+		let objectCount = 0;
+		let totalSize = 0;
+		let continuationToken: string | undefined;
+		do {
+			const result = await this.client.send(
+				new ListObjectsV2Command({
+					Bucket: name,
+					...(continuationToken !== undefined && {ContinuationToken: continuationToken}),
+				}),
+			);
+			for (const obj of result.Contents ?? []) {
+				objectCount++;
+				totalSize += obj.Size ?? 0;
+			}
+			continuationToken = result.NextContinuationToken;
+		} while (continuationToken !== undefined);
+		return {objectCount, totalSize};
 	}
 
 	public async listObjects(

--- a/api/src/storage.ts
+++ b/api/src/storage.ts
@@ -1,4 +1,4 @@
-import type {Bucket, S3Object} from '@shared/types';
+import type {Bucket, BucketStats, S3Object} from '@shared/types';
 
 export interface ObjectStream {
 	body: ReadableStream<Uint8Array>;
@@ -13,6 +13,7 @@ export interface ListObjectsResult {
 
 export interface Storage {
 	listBuckets(): Promise<Bucket[]>;
+	getBucketStats(name: string): Promise<BucketStats>;
 	listObjects(
 		bucket: string,
 		prefix: string,

--- a/frontend/src/__tests__/BucketListPage.test.tsx
+++ b/frontend/src/__tests__/BucketListPage.test.tsx
@@ -5,15 +5,18 @@ import {Notifications} from '@mantine/notifications';
 import {http, HttpResponse} from 'msw';
 import {setupServer} from 'msw/node';
 import {BucketListPage} from '../pages/BucketListPage';
-import type {Bucket} from '@shared/types';
+import type {Bucket, BucketStats} from '@shared/types';
 
 const mockBuckets: Bucket[] = [
-	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z'},
-	{name: 'another-bucket', creationDate: '2024-02-01T00:00:00.000Z'},
+	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z', region: 'us-east-1'},
+	{name: 'another-bucket', creationDate: '2024-02-01T00:00:00.000Z', region: 'eu-west-1'},
 ];
+
+const mockStats: BucketStats = {objectCount: 42, totalSize: 1024 * 1024};
 
 const server = setupServer(
 	http.get('/api/buckets', () => HttpResponse.json({buckets: mockBuckets})),
+	http.get('/api/buckets/:bucket/stats', () => HttpResponse.json(mockStats)),
 );
 
 beforeAll(() => {
@@ -45,7 +48,42 @@ describe('BucketListPage', () => {
 		});
 	});
 
-	it('shows error toast on fetch failure', async () => {
+	it('renders region badges', async () => {
+		renderPage();
+		await waitFor(() => {
+			expect(screen.getByText('us-east-1')).toBeInTheDocument();
+			expect(screen.getByText('eu-west-1')).toBeInTheDocument();
+		});
+	});
+
+	it('renders creation dates', async () => {
+		renderPage();
+		await waitFor(() => {
+			const dateTexts = screen.getAllByText(/Created/);
+			expect(dateTexts.length).toBeGreaterThanOrEqual(2);
+		});
+	});
+
+	it('renders async stats after loading', async () => {
+		renderPage();
+		await waitFor(() => {
+			const objectTexts = screen.getAllByText('42 objects');
+			expect(objectTexts.length).toBe(2);
+		});
+	});
+
+	it('shows error fallback when stats fetch fails', async () => {
+		server.use(
+			http.get('/api/buckets/:bucket/stats', () => new HttpResponse(null, {status: 500})),
+		);
+		renderPage();
+		await waitFor(() => {
+			const unavailable = screen.getAllByText('unavailable');
+			expect(unavailable.length).toBe(2);
+		});
+	});
+
+	it('shows error toast on buckets fetch failure', async () => {
 		server.use(http.get('/api/buckets', () => new HttpResponse(null, {status: 500})));
 		renderPage();
 		await waitFor(() => {

--- a/frontend/src/__tests__/client.test.ts
+++ b/frontend/src/__tests__/client.test.ts
@@ -5,8 +5,8 @@ import {fetchBuckets, fetchFolderSize, fetchObjects} from '../api/client';
 import type {Bucket, S3Object} from '@shared/types';
 
 const mockBuckets: Bucket[] = [
-	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z'},
-	{name: 'other-bucket', creationDate: '2024-02-01T00:00:00.000Z'},
+	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z', region: 'us-east-1'},
+	{name: 'other-bucket', creationDate: '2024-02-01T00:00:00.000Z', region: 'eu-west-1'},
 ];
 
 const mockObjects: S3Object[] = [

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-import type {Bucket, S3Object} from '@shared/types';
+import type {Bucket, BucketStats, S3Object} from '@shared/types';
 
 export interface FetchObjectsResult {
 	objects: S3Object[];
@@ -33,6 +33,14 @@ export async function fetchObjects(
 	}
 	const data = (await res.json()) as {objects: S3Object[]; totalCount: number};
 	return {objects: data.objects, totalCount: data.totalCount};
+}
+
+export async function fetchBucketStats(bucket: string): Promise<BucketStats> {
+	const res = await fetch(`/api/buckets/${encodeURIComponent(bucket)}/stats`);
+	if (!res.ok) {
+		throw new Error(`Failed to fetch stats for ${bucket}: ${res.status}`);
+	}
+	return (await res.json()) as BucketStats;
 }
 
 export async function fetchFolderSize(bucket: string, prefix: string): Promise<number> {

--- a/frontend/src/pages/BucketListPage.tsx
+++ b/frontend/src/pages/BucketListPage.tsx
@@ -1,9 +1,77 @@
 import {useEffect, useState} from 'react';
-import {Container, Title, Stack, Text, Paper, Anchor} from '@mantine/core';
+import {Container, Title, Stack, Text, Paper, Anchor, Group, Loader, Badge} from '@mantine/core';
 import {notifications} from '@mantine/notifications';
 import {Link} from 'react-router-dom';
-import type {Bucket} from '@shared/types';
-import {fetchBuckets} from '../api/client';
+import type {Bucket, BucketStats} from '@shared/types';
+import {fetchBuckets, fetchBucketStats} from '../api/client';
+import {formatDate, formatSize} from '../utils/format';
+
+type StatsState = {status: 'loading'} | {status: 'ok'; data: BucketStats} | {status: 'error'};
+
+const BucketCard = ({bucket}: {bucket: Bucket}) => {
+	const [stats, setStats] = useState<StatsState>({status: 'loading'});
+
+	useEffect(() => {
+		let cancelled = false;
+		void fetchBucketStats(bucket.name)
+			.then((data) => {
+				if (!cancelled) {
+					setStats({status: 'ok', data});
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setStats({status: 'error'});
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [bucket.name]);
+
+	return (
+		<Paper withBorder p="md" w="100%">
+			<Group justify="space-between" wrap="nowrap" align="flex-start">
+				<Stack gap={4}>
+					<Anchor
+						component={Link}
+						to={`/buckets/${bucket.name}`}
+						style={{wordBreak: 'break-all'}}
+						fw={500}
+					>
+						{bucket.name}
+					</Anchor>
+					<Group gap="xs">
+						{bucket.region !== '' && (
+							<Badge variant="light" size="sm">
+								{bucket.region}
+							</Badge>
+						)}
+						<Text size="xs" c="dimmed">
+							Created {formatDate(bucket.creationDate)}
+						</Text>
+					</Group>
+				</Stack>
+				<Stack gap={2} align="flex-end" style={{flexShrink: 0}}>
+					{stats.status === 'loading' && <Loader size="xs" />}
+					{stats.status === 'error' && (
+						<Text size="xs" c="dimmed">
+							unavailable
+						</Text>
+					)}
+					{stats.status === 'ok' && (
+						<>
+							<Text size="sm">{stats.data.objectCount.toLocaleString()} objects</Text>
+							<Text size="xs" c="dimmed">
+								{formatSize(stats.data.totalSize)}
+							</Text>
+						</>
+					)}
+				</Stack>
+			</Group>
+		</Paper>
+	);
+};
 
 export const BucketListPage = () => {
 	const [buckets, setBuckets] = useState<Bucket[]>([]);
@@ -38,19 +106,11 @@ export const BucketListPage = () => {
 	}
 
 	return (
-		<Container size="md" py="xl">
+		<Container size="lg" py="xl">
 			<Title mb="md">Buckets</Title>
 			<Stack gap="xs">
 				{buckets.map((bucket) => (
-					<Paper key={bucket.name} withBorder p="sm">
-						<Anchor
-							component={Link}
-							to={`/buckets/${bucket.name}`}
-							style={{wordBreak: 'break-all'}}
-						>
-							{bucket.name}
-						</Anchor>
-					</Paper>
+					<BucketCard key={bucket.name} bucket={bucket} />
 				))}
 			</Stack>
 		</Container>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,6 +1,12 @@
 export interface Bucket {
 	name: string;
 	creationDate: string;
+	region: string;
+}
+
+export interface BucketStats {
+	objectCount: number;
+	totalSize: number;
 }
 
 export interface S3Object {


### PR DESCRIPTION
## Summary
- Expand bucket list container `md→lg` to match object browser width; cards stretch full width
- Add `region` field to `Bucket` type + API response (from `BucketRegion` in `ListBucketsCommand`)
- Add `GET /api/buckets/:bucket/stats` endpoint returning `objectCount` + `totalSize` via paginated `ListObjectsV2`
- Bucket cards show region badge, creation date, and async stats (loader → count/size or "unavailable" fallback)

## Test plan
- [ ] `GET /api/buckets` response includes `region` per bucket
- [ ] `GET /api/buckets/:bucket/stats` returns correct counts and sizes; empty bucket returns zeros
- [ ] Bucket cards render region + date
- [ ] Stats load async — loader shown, then count + human-readable size
- [ ] Single stat failure shows "unavailable", page doesn't crash

Closes #23, #24, #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)