### PR TITLE
feat(upload): drag-and-drop upload with recursive folder support

### DIFF
--- a/frontend/src/__tests__/ObjectBrowser.test.tsx
+++ b/frontend/src/__tests__/ObjectBrowser.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {MantineProvider} from '@mantine/core';
@@ -184,6 +184,36 @@ describe('ObjectBrowser', () => {
 		await user.click(screen.getByRole('button', {name: /^delete$/i}));
 		await waitFor(() => {
 			expect(deleteCalled).toBe(true);
+		});
+	});
+
+	it('drag overlay is absent under normal conditions', async () => {
+		renderPage('/buckets/my-bucket');
+		await waitFor(() => screen.getByText('readme.txt'));
+		expect(screen.queryByLabelText('Drop to upload')).not.toBeInTheDocument();
+	});
+
+	it('drag overlay appears when dragging over the browser container', async () => {
+		renderPage('/buckets/my-bucket');
+		await waitFor(() => screen.getByText('readme.txt'));
+		const container = screen.getByTestId('object-browser');
+		fireEvent.dragEnter(container);
+		await waitFor(() => {
+			expect(screen.getByLabelText('Drop to upload')).toBeInTheDocument();
+		});
+	});
+
+	it('drag overlay disappears when dragging out of the browser container', async () => {
+		renderPage('/buckets/my-bucket');
+		await waitFor(() => screen.getByText('readme.txt'));
+		const container = screen.getByTestId('object-browser');
+		fireEvent.dragEnter(container);
+		await waitFor(() => {
+			expect(screen.getByLabelText('Drop to upload')).toBeInTheDocument();
+		});
+		fireEvent.dragLeave(container);
+		await waitFor(() => {
+			expect(screen.queryByLabelText('Drop to upload')).not.toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/__tests__/ObjectBrowserPage.test.tsx
+++ b/frontend/src/__tests__/ObjectBrowserPage.test.tsx
@@ -8,12 +8,15 @@ import {setupServer} from 'msw/node';
 import {vi} from 'vitest';
 import {ObjectBrowserPage} from '../pages/ObjectBrowserPage';
 import type {S3Object} from '@shared/types';
+import * as resolveDropEntriesModule from '../utils/resolveDropEntries';
 
 vi.mock('streamsaver', () => ({
 	default: {
 		createWriteStream: vi.fn(() => new WritableStream()),
 	},
 }));
+
+vi.mock('../utils/resolveDropEntries');
 
 const mockObjects: S3Object[] = [
 	{key: 'docs/', size: 0, lastModified: '', isPrefix: true},
@@ -157,6 +160,88 @@ describe('ObjectBrowserPage', () => {
 		await user.click(screen.getByRole('button', {name: /open folder docs\//i}));
 		await waitFor(() => {
 			expect(capturedUrl).toContain('offset=0');
+		});
+	});
+
+	it('drop event triggers multipart upload with the resolved file key', async () => {
+		const droppedFile = new File(['hello'], 'dropped.txt', {type: 'text/plain'});
+		vi.mocked(resolveDropEntriesModule.resolveDropEntries).mockResolvedValue([
+			{file: droppedFile, relativePath: 'dropped.txt'},
+		]);
+
+		let createKey = '';
+		let partKey = '';
+		let completeKey = '';
+		server.use(
+			http.post('/api/buckets/:bucket/multipart/create', ({request}) => {
+				const url = new URL(request.url);
+				createKey = url.searchParams.get('key') ?? '';
+				return HttpResponse.json({uploadId: 'test-id'});
+			}),
+			http.put('/api/buckets/:bucket/multipart/part', ({request}) => {
+				const url = new URL(request.url);
+				partKey = url.searchParams.get('key') ?? '';
+				return HttpResponse.json({etag: '"etag1"'});
+			}),
+			http.post('/api/buckets/:bucket/multipart/complete', ({request}) => {
+				const url = new URL(request.url);
+				completeKey = url.searchParams.get('key') ?? '';
+				return HttpResponse.json({});
+			}),
+		);
+
+		renderPage('/buckets/my-bucket');
+		await waitFor(() => screen.getByText('readme.txt'));
+
+		const container = screen.getByTestId('object-browser');
+		const dropEvent = new Event('drop', {bubbles: true, cancelable: true});
+		Object.defineProperty(dropEvent, 'dataTransfer', {
+			value: {items: {} as DataTransferItemList},
+			writable: false,
+		});
+		container.dispatchEvent(dropEvent);
+
+		await waitFor(() => {
+			expect(createKey).toBe('dropped.txt');
+			expect(partKey).toBe('dropped.txt');
+			expect(completeKey).toBe('dropped.txt');
+		});
+	});
+
+	it('drop upload error shows "Upload failed" notification and aborts the multipart upload', async () => {
+		const droppedFile = new File(['hello'], 'fail.txt', {type: 'text/plain'});
+		vi.mocked(resolveDropEntriesModule.resolveDropEntries).mockResolvedValue([
+			{file: droppedFile, relativePath: 'fail.txt'},
+		]);
+
+		let abortCalled = false;
+		server.use(
+			http.post('/api/buckets/:bucket/multipart/create', () =>
+				HttpResponse.json({uploadId: 'fail-id'}),
+			),
+			http.put(
+				'/api/buckets/:bucket/multipart/part',
+				() => new HttpResponse(null, {status: 500}),
+			),
+			http.delete('/api/buckets/:bucket/multipart', () => {
+				abortCalled = true;
+				return HttpResponse.json({});
+			}),
+		);
+
+		renderPage('/buckets/my-bucket');
+		await waitFor(() => screen.getByText('readme.txt'));
+
+		const dropEvent = new Event('drop', {bubbles: true, cancelable: true});
+		Object.defineProperty(dropEvent, 'dataTransfer', {
+			value: {items: {} as DataTransferItemList},
+			writable: false,
+		});
+		screen.getByTestId('object-browser').dispatchEvent(dropEvent);
+
+		await waitFor(() => {
+			expect(screen.getByText('Upload failed')).toBeInTheDocument();
+			expect(abortCalled).toBe(true);
 		});
 	});
 

--- a/frontend/src/__tests__/resolveDropEntries.test.tsx
+++ b/frontend/src/__tests__/resolveDropEntries.test.tsx
@@ -1,0 +1,143 @@
+import {describe, expect, it} from 'vitest';
+import {resolveDropEntries} from '../utils/resolveDropEntries';
+
+function makeFile(name: string): File {
+	return new File(['content'], name);
+}
+
+function makeFileEntry(file: File): FileSystemFileEntry {
+	return {
+		name: file.name,
+		isFile: true,
+		isDirectory: false,
+		fullPath: `/${file.name}`,
+		filesystem: null as unknown as FileSystem,
+		getParent: () => undefined,
+		file: (success: (file: File) => void) => {
+			success(file);
+		},
+	} as unknown as FileSystemFileEntry;
+}
+
+function makeDirectoryEntry(
+	name: string,
+	children: FileSystemEntry[],
+	batchSize?: number,
+): FileSystemDirectoryEntry {
+	const batch = batchSize ?? children.length;
+	return {
+		name,
+		isFile: false,
+		isDirectory: true,
+		fullPath: `/${name}`,
+		filesystem: null as unknown as FileSystem,
+		getParent: () => undefined,
+		createReader: (): FileSystemDirectoryReader => {
+			let idx = 0;
+			return {
+				readEntries: (success: (entries: FileSystemEntry[]) => void) => {
+					const slice = children.slice(idx, idx + batch);
+					idx += batch;
+					success(slice);
+				},
+			};
+		},
+	} as unknown as FileSystemDirectoryEntry;
+}
+
+function makeItemList(entries: FileSystemEntry[]): DataTransferItemList {
+	const items = entries.map((entry) => ({
+		kind: 'file' as const,
+		type: '',
+		getAsFile: () => null,
+		getAsString: (_: (s: string) => void) => undefined,
+		webkitGetAsEntry: () => entry,
+	}));
+	const obj = {
+		length: items.length,
+		add: () => null,
+		clear: () => undefined,
+		remove: () => undefined,
+		[Symbol.iterator]: function* () {
+			yield* items;
+		},
+	} as unknown as DataTransferItemList;
+	for (let i = 0; i < items.length; i++) {
+		(obj as unknown as Record<number, (typeof items)[number]>)[i] = items[i]!;
+	}
+	return obj;
+}
+
+describe('resolveDropEntries — flat files (Phase 1)', () => {
+	it('resolves flat files with correct relativePath', async () => {
+		const file1 = makeFile('a.txt');
+		const file2 = makeFile('b.png');
+		const list = makeItemList([makeFileEntry(file1), makeFileEntry(file2)]);
+
+		const result = await resolveDropEntries(list);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({file: file1, relativePath: 'a.txt'});
+		expect(result[1]).toEqual({file: file2, relativePath: 'b.png'});
+	});
+
+	it('returns an empty array for an empty item list', async () => {
+		const list = makeItemList([]);
+		const result = await resolveDropEntries(list);
+		expect(result).toEqual([]);
+	});
+});
+
+describe('resolveDropEntries — recursive folders (Phase 2)', () => {
+	it('resolves a single-level directory with correct relative paths', async () => {
+		const file1 = makeFile('img.png');
+		const file2 = makeFile('notes.txt');
+		const dirEntry = makeDirectoryEntry('mydir', [makeFileEntry(file1), makeFileEntry(file2)]);
+		const list = makeItemList([dirEntry]);
+
+		const result = await resolveDropEntries(list);
+
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.relativePath).sort()).toEqual([
+			'mydir/img.png',
+			'mydir/notes.txt',
+		]);
+	});
+
+	it('resolves deeply nested directories with correct relative paths', async () => {
+		const deepFile = makeFile('deep.txt');
+		const inner = makeDirectoryEntry('inner', [makeFileEntry(deepFile)]);
+		const outer = makeDirectoryEntry('outer', [inner]);
+		const list = makeItemList([outer]);
+
+		const result = await resolveDropEntries(list);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.relativePath).toBe('outer/inner/deep.txt');
+	});
+
+	it('handles a mixed drop of loose files and folders', async () => {
+		const looseFile = makeFile('loose.txt');
+		const dirFile = makeFile('inside.txt');
+		const dirEntry = makeDirectoryEntry('myfolder', [makeFileEntry(dirFile)]);
+		const list = makeItemList([makeFileEntry(looseFile), dirEntry]);
+
+		const result = await resolveDropEntries(list);
+
+		expect(result).toHaveLength(2);
+		const paths = result.map((r) => r.relativePath).sort();
+		expect(paths).toEqual(['loose.txt', 'myfolder/inside.txt']);
+	});
+
+	it('fully resolves a directory with more than 100 entries via readEntries loop', async () => {
+		const files = Array.from({length: 101}, (_, i) => makeFile(`file${i}.txt`));
+		const fileEntries = files.map((f) => makeFileEntry(f));
+		const dirEntry = makeDirectoryEntry('bigdir', fileEntries, 100);
+		const list = makeItemList([dirEntry]);
+
+		const result = await resolveDropEntries(list);
+
+		expect(result).toHaveLength(101);
+		expect(result.every((r) => r.relativePath.startsWith('bigdir/'))).toBe(true);
+	});
+});

--- a/frontend/src/__tests__/useDragUpload.test.tsx
+++ b/frontend/src/__tests__/useDragUpload.test.tsx
@@ -1,0 +1,88 @@
+import {act, renderHook} from '@testing-library/react';
+import {vi, describe, it, expect, beforeEach} from 'vitest';
+import {useDragUpload} from '../hooks/useDragUpload';
+
+vi.mock('../utils/resolveDropEntries', () => ({
+	resolveDropEntries: vi.fn(),
+}));
+
+import * as resolveDropEntriesModule from '../utils/resolveDropEntries';
+
+const makeDragEvent = (): React.DragEvent<HTMLDivElement> =>
+	({
+		preventDefault: vi.fn(),
+		dataTransfer: {items: {} as DataTransferItemList},
+	}) as unknown as React.DragEvent<HTMLDivElement>;
+
+describe('useDragUpload', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('isDragging becomes true on dragenter', () => {
+		const {result} = renderHook(() => useDragUpload({disabled: false, onDrop: vi.fn()}));
+
+		act(() => {
+			result.current.dragProps.onDragEnter(makeDragEvent());
+		});
+
+		expect(result.current.isDragging).toBe(true);
+	});
+
+	it('isDragging reverts to false after matching number of dragleave events', () => {
+		const {result} = renderHook(() => useDragUpload({disabled: false, onDrop: vi.fn()}));
+
+		act(() => {
+			result.current.dragProps.onDragEnter(makeDragEvent());
+			result.current.dragProps.onDragEnter(makeDragEvent());
+		});
+		expect(result.current.isDragging).toBe(true);
+
+		act(() => {
+			result.current.dragProps.onDragLeave(makeDragEvent());
+		});
+		expect(result.current.isDragging).toBe(true);
+
+		act(() => {
+			result.current.dragProps.onDragLeave(makeDragEvent());
+		});
+		expect(result.current.isDragging).toBe(false);
+	});
+
+	it('onDrop callback is called with resolved entries on drop', async () => {
+		const resolvedFiles = [{file: new File(['x'], 'x.txt'), relativePath: 'x.txt'}];
+		vi.mocked(resolveDropEntriesModule.resolveDropEntries).mockResolvedValue(resolvedFiles);
+
+		const onDrop = vi.fn();
+		const {result} = renderHook(() => useDragUpload({disabled: false, onDrop}));
+
+		await act(async () => {
+			result.current.dragProps.onDrop(makeDragEvent());
+		});
+
+		expect(onDrop).toHaveBeenCalledWith(resolvedFiles);
+	});
+
+	it('all handlers are no-ops when disabled is true', () => {
+		const onDrop = vi.fn();
+		const {result} = renderHook(() => useDragUpload({disabled: true, onDrop}));
+
+		act(() => {
+			result.current.dragProps.onDragEnter(makeDragEvent());
+		});
+
+		expect(result.current.isDragging).toBe(false);
+		expect(onDrop).not.toHaveBeenCalled();
+	});
+
+	it('isDragging stays false when disabled even after dragenter', () => {
+		const {result} = renderHook(() => useDragUpload({disabled: true, onDrop: vi.fn()}));
+
+		act(() => {
+			result.current.dragProps.onDragEnter(makeDragEvent());
+			result.current.dragProps.onDragOver(makeDragEvent());
+		});
+
+		expect(result.current.isDragging).toBe(false);
+	});
+});

--- a/frontend/src/components/DragOverlay.tsx
+++ b/frontend/src/components/DragOverlay.tsx
@@ -1,0 +1,36 @@
+interface DragOverlayProps {
+	show: boolean;
+}
+
+export const DragOverlay = ({show}: DragOverlayProps) => {
+	if (!show) {
+		return null;
+	}
+
+	return (
+		<div
+			aria-label="Drop to upload"
+			style={{
+				position: 'absolute',
+				inset: 0,
+				zIndex: 50,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'rgba(0, 0, 0, 0.55)',
+				pointerEvents: 'none',
+			}}
+		>
+			<span
+				style={{
+					fontSize: 20,
+					fontWeight: 600,
+					color: 'var(--accent-text, #4ade80)',
+					userSelect: 'none',
+				}}
+			>
+				Drop to upload
+			</span>
+		</div>
+	);
+};

--- a/frontend/src/components/ObjectBrowser.tsx
+++ b/frontend/src/components/ObjectBrowser.tsx
@@ -15,6 +15,7 @@ import streamSaver from 'streamsaver';
 import type {S3Object} from '@shared/types';
 import {buildBreadcrumbSegments} from '../utils/breadcrumbs';
 import {formatDate, formatSize} from '../utils/format';
+import {DragOverlay} from './DragOverlay';
 import {GalleryView} from './GalleryView';
 import {PaginationControls} from './Pagination';
 
@@ -35,6 +36,8 @@ interface ObjectBrowserProps {
 	pageSize: number;
 	selectedKey: string | null;
 	uploadProgress: UploadProgress | null;
+	isDragging: boolean;
+	dragProps: React.HTMLAttributes<HTMLDivElement>;
 	onNavigate: (prefix: string) => void;
 	onSelectObject: (key: string | null) => void;
 	onPageChange: (page: number) => void;
@@ -86,6 +89,8 @@ export const ObjectBrowser = ({
 	pageSize,
 	selectedKey,
 	uploadProgress,
+	isDragging,
+	dragProps,
 	onNavigate,
 	onSelectObject,
 	onPageChange,
@@ -165,7 +170,12 @@ export const ObjectBrowser = ({
 	};
 
 	return (
-		<div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+		<div
+			data-testid="object-browser"
+			style={{display: 'flex', flexDirection: 'column', height: '100%', position: 'relative'}}
+			{...dragProps}
+		>
+			<DragOverlay show={isDragging} />
 			{/* Top bar */}
 			<div
 				style={{

--- a/frontend/src/hooks/useDragUpload.ts
+++ b/frontend/src/hooks/useDragUpload.ts
@@ -1,0 +1,76 @@
+import {useCallback, useRef, useState} from 'react';
+import {resolveDropEntries} from '../utils/resolveDropEntries';
+import type {ResolvedFile} from '../utils/resolveDropEntries';
+
+interface UseDragUploadOptions {
+	disabled: boolean;
+	onDrop: (files: ResolvedFile[]) => void;
+}
+
+export interface DragProps {
+	onDragEnter: React.DragEventHandler<HTMLDivElement>;
+	onDragOver: React.DragEventHandler<HTMLDivElement>;
+	onDragLeave: React.DragEventHandler<HTMLDivElement>;
+	onDrop: React.DragEventHandler<HTMLDivElement>;
+}
+
+export interface UseDragUploadResult {
+	isDragging: boolean;
+	dragProps: DragProps;
+}
+
+export const useDragUpload = ({disabled, onDrop}: UseDragUploadOptions): UseDragUploadResult => {
+	const [dragCounter, setDragCounter] = useState(0);
+	const disabledRef = useRef(disabled);
+	disabledRef.current = disabled;
+	const onDropRef = useRef(onDrop);
+	onDropRef.current = onDrop;
+
+	const handleDragEnter = useCallback<React.DragEventHandler<HTMLDivElement>>((e) => {
+		if (disabledRef.current) {
+			return;
+		}
+		e.preventDefault();
+		setDragCounter((c) => c + 1);
+	}, []);
+
+	const handleDragOver = useCallback<React.DragEventHandler<HTMLDivElement>>((e) => {
+		if (disabledRef.current) {
+			return;
+		}
+		e.preventDefault();
+	}, []);
+
+	const handleDragLeave = useCallback<React.DragEventHandler<HTMLDivElement>>((e) => {
+		if (disabledRef.current) {
+			return;
+		}
+		e.preventDefault();
+		setDragCounter((c) => Math.max(0, c - 1));
+	}, []);
+
+	const handleDrop = useCallback<React.DragEventHandler<HTMLDivElement>>((e) => {
+		if (disabledRef.current) {
+			return;
+		}
+		e.preventDefault();
+		setDragCounter(0);
+		void resolveDropEntries(e.dataTransfer.items)
+			.then((files) => {
+				onDropRef.current(files);
+			})
+			.catch(() => {
+				// FileSystem API errors are rare; silently ignore to avoid unhandled rejection
+			});
+	}, []);
+
+	return {
+		isDragging: !disabled && dragCounter > 0,
+		dragProps: {
+			onDragEnter: handleDragEnter,
+			onDragOver: handleDragOver,
+			onDragLeave: handleDragLeave,
+			onDrop: handleDrop,
+		},
+	};
+};

--- a/frontend/src/pages/ObjectBrowserPage.tsx
+++ b/frontend/src/pages/ObjectBrowserPage.tsx
@@ -13,6 +13,8 @@ import {
 } from '../api/client';
 import {ObjectBrowser} from '../components/ObjectBrowser';
 import {ObjectInspector} from '../components/ObjectInspector';
+import {useDragUpload} from '../hooks/useDragUpload';
+import type {ResolvedFile} from '../utils/resolveDropEntries';
 
 interface UploadProgress {
 	done: number;
@@ -176,19 +178,16 @@ export const ObjectBrowserPage = () => {
 		await res.body.pipeTo(fileStream);
 	};
 
-	const uploadFiles = async (files: FileList): Promise<void> => {
-		const fileArray = Array.from(files);
+	const uploadFilesWithPaths = async (files: ResolvedFile[]): Promise<void> => {
 		try {
-			for (const [i, file] of fileArray.entries()) {
-				const relativePath =
-					file.webkitRelativePath !== '' ? file.webkitRelativePath : file.name;
+			for (const [i, {file, relativePath}] of files.entries()) {
 				const key = prefix + relativePath;
 				const contentType = file.type !== '' ? file.type : undefined;
 				const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_SIZE));
 
 				setUploadProgress({
 					done: i,
-					total: fileArray.length,
+					total: files.length,
 					filename: file.name,
 					fileProgress: 0,
 				});
@@ -210,7 +209,7 @@ export const ObjectBrowserPage = () => {
 							(loaded) => {
 								setUploadProgress({
 									done: i,
-									total: fileArray.length,
+									total: files.length,
 									filename: file.name,
 									fileProgress: Math.round(
 										((bytesUploaded + loaded) / Math.max(file.size, 1)) * 100,
@@ -238,6 +237,21 @@ export const ObjectBrowserPage = () => {
 			setRefreshKey((k) => k + 1);
 		}
 	};
+
+	const uploadFiles = async (files: FileList): Promise<void> => {
+		const resolved: ResolvedFile[] = Array.from(files).map((file) => ({
+			file,
+			relativePath: file.webkitRelativePath !== '' ? file.webkitRelativePath : file.name,
+		}));
+		await uploadFilesWithPaths(resolved);
+	};
+
+	const {isDragging, dragProps} = useDragUpload({
+		disabled: uploadProgress !== null,
+		onDrop: (files) => {
+			void uploadFilesWithPaths(files);
+		},
+	});
 
 	const selectedObject =
 		selectedKey !== null ? objects.find((o) => o.key === selectedKey) : undefined;
@@ -344,6 +358,8 @@ export const ObjectBrowserPage = () => {
 							pageSize={pageSize}
 							selectedKey={selectedKey}
 							uploadProgress={uploadProgress}
+							isDragging={isDragging}
+							dragProps={dragProps}
 							onNavigate={navigateTo}
 							onSelectObject={selectObject}
 							onPageChange={handlePageChange}
@@ -374,6 +390,8 @@ export const ObjectBrowserPage = () => {
 						pageSize={pageSize}
 						selectedKey={selectedKey}
 						uploadProgress={uploadProgress}
+						isDragging={isDragging}
+						dragProps={dragProps}
 						onNavigate={navigateTo}
 						onSelectObject={selectObject}
 						onPageChange={handlePageChange}

--- a/frontend/src/utils/resolveDropEntries.ts
+++ b/frontend/src/utils/resolveDropEntries.ts
@@ -1,0 +1,49 @@
+export interface ResolvedFile {
+	file: File;
+	relativePath: string;
+}
+
+export const resolveDropEntries = (items: DataTransferItemList): Promise<ResolvedFile[]> => {
+	const entries: FileSystemEntry[] = [];
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		if (item?.kind === 'file') {
+			const entry = item.webkitGetAsEntry();
+			if (entry !== null) {
+				entries.push(entry);
+			}
+		}
+	}
+	return Promise.all(entries.map((e) => resolveEntry(e, ''))).then((results) => results.flat());
+};
+
+function resolveEntry(entry: FileSystemEntry, basePath: string): Promise<ResolvedFile[]> {
+	if (entry.isFile) {
+		return new Promise<ResolvedFile[]>((resolve, reject) => {
+			(entry as FileSystemFileEntry).file((file) => {
+				const relativePath = basePath !== '' ? `${basePath}/${entry.name}` : entry.name;
+				resolve([{file, relativePath}]);
+			}, reject);
+		});
+	}
+	const dirPath = basePath !== '' ? `${basePath}/${entry.name}` : entry.name;
+	return readAllEntries((entry as FileSystemDirectoryEntry).createReader()).then((children) =>
+		Promise.all(children.map((child) => resolveEntry(child, dirPath))).then((results) =>
+			results.flat(),
+		),
+	);
+}
+
+async function readAllEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+	const all: FileSystemEntry[] = [];
+	for (;;) {
+		const batch = await new Promise<FileSystemEntry[]>((resolve, reject) => {
+			reader.readEntries(resolve, reject);
+		});
+		if (batch.length === 0) {
+			break;
+		}
+		all.push(...batch);
+	}
+	return all;
+}


### PR DESCRIPTION
## Summary
- **Phase 1 (#49)**: Drop zone scaffold + flat-file upload — `DragOverlay`, `useDragUpload` hook (enter/leave counter strategy), `resolveDropEntries` utility, ObjectBrowser/ObjectBrowserPage wiring
- **Phase 2 (#50)**: Recursive folder / mixed drop — `resolveDropEntries` extended with `FileSystemDirectoryEntry` recursion and `readEntries` loop for >100-entry directories

## Test plan
- [ ] `resolveDropEntries`: flat files, empty list, single-level dir, deeply nested dirs, mixed file+folder, >100-entry batch loop
- [ ] `useDragUpload`: isDragging toggling, disabled no-ops, onDrop called with resolved entries
- [ ] `ObjectBrowser`: overlay absent normally, appears on dragenter, disappears on dragleave
- [ ] `ObjectBrowserPage`: drop triggers multipart upload with correct key; drop upload error shows notification and aborts

Closes #48, #49, #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)