### PR TITLE
feat(ui): mobile / responsive layout

### DIFF
--- a/frontend/src/__tests__/responsive.test.tsx
+++ b/frontend/src/__tests__/responsive.test.tsx
@@ -1,0 +1,363 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {MantineProvider} from '@mantine/core';
+import {Notifications} from '@mantine/notifications';
+import {http, HttpResponse} from 'msw';
+import {setupServer} from 'msw/node';
+import {vi} from 'vitest';
+import {BucketsProvider} from '../contexts/BucketsContext';
+import {AppShell} from '../components/AppShell';
+import {BucketListPage} from '../pages/BucketListPage';
+import {ObjectBrowserPage} from '../pages/ObjectBrowserPage';
+import type {Bucket, BucketStats, S3Object} from '@shared/types';
+
+vi.mock('streamsaver', () => ({
+	default: {
+		createWriteStream: vi.fn(() => new WritableStream()),
+	},
+}));
+
+const mockBuckets: Bucket[] = [
+	{name: 'my-bucket', creationDate: '2024-01-01T00:00:00.000Z', region: 'us-east-1'},
+	{name: 'another-bucket', creationDate: '2024-02-01T00:00:00.000Z', region: 'eu-west-1'},
+];
+
+const mockStats: BucketStats = {objectCount: 5, totalSize: 1024};
+
+const mockObjects: S3Object[] = [
+	{key: 'docs/', size: 0, lastModified: '', isPrefix: true},
+	{key: 'readme.txt', size: 1024, lastModified: '2024-01-01T00:00:00.000Z', isPrefix: false},
+	{key: 'photo.jpg', size: 2048, lastModified: '2024-01-02T00:00:00.000Z', isPrefix: false},
+	{key: 'photo2.jpg', size: 3072, lastModified: '2024-01-03T00:00:00.000Z', isPrefix: false},
+];
+
+const server = setupServer(
+	http.get('/api/buckets', () => HttpResponse.json({buckets: mockBuckets})),
+	http.get('/api/buckets/:bucket/stats', () => HttpResponse.json(mockStats)),
+	http.get('/api/buckets/:bucket/objects', () =>
+		HttpResponse.json({objects: mockObjects, totalCount: mockObjects.length}),
+	),
+);
+
+beforeAll(() => {
+	server.listen();
+});
+afterEach(() => {
+	server.resetHandlers();
+	vi.restoreAllMocks();
+});
+afterAll(() => {
+	server.close();
+});
+
+const mockResizeObserver = (width: number) => {
+	const callbacks: ResizeObserverCallback[] = [];
+	vi.spyOn(globalThis, 'ResizeObserver').mockImplementation((cb: ResizeObserverCallback) => {
+		callbacks.push(cb);
+		return {
+			observe: (target: Element) => {
+				cb(
+					[
+						{
+							contentRect: {
+								width,
+								height: 800,
+								top: 0,
+								left: 0,
+								right: width,
+								bottom: 800,
+								x: 0,
+								y: 0,
+								toJSON: () => ({}),
+							},
+							borderBoxSize: [],
+							contentBoxSize: [],
+							devicePixelContentBoxSize: [],
+							target,
+						},
+					],
+					{} as ResizeObserver,
+				);
+			},
+			unobserve: () => {},
+			disconnect: () => {},
+		};
+	});
+};
+
+const renderAtWidth = (path: string, width: number) => {
+	mockResizeObserver(width);
+	return render(
+		<MantineProvider>
+			<Notifications />
+			<MemoryRouter initialEntries={[path]}>
+				<BucketsProvider>
+					<AppShell>
+						<Routes>
+							<Route path="/" element={<BucketListPage />} />
+							<Route path="/buckets/:bucket" element={<ObjectBrowserPage />} />
+						</Routes>
+					</AppShell>
+				</BucketsProvider>
+			</MemoryRouter>
+		</MantineProvider>,
+	);
+};
+
+describe('AppShell — mobile (390px)', () => {
+	it('renders hamburger button on mobile', async () => {
+		renderAtWidth('/', 390);
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /open navigation drawer/i}),
+			).toBeInTheDocument();
+		});
+	});
+
+	it('clicking hamburger opens the drawer', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/', 390);
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /open navigation drawer/i}),
+			).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole('button', {name: /open navigation drawer/i}));
+		expect(screen.getByRole('dialog', {name: /navigation drawer/i})).toBeInTheDocument();
+	});
+
+	it('clicking close button dismisses the drawer', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/', 390);
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /open navigation drawer/i}),
+			).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole('button', {name: /open navigation drawer/i}));
+		expect(screen.getByRole('dialog', {name: /navigation drawer/i})).toBeInTheDocument();
+		await user.click(screen.getByRole('button', {name: /close drawer/i}));
+		expect(screen.queryByRole('dialog', {name: /navigation drawer/i})).not.toBeInTheDocument();
+	});
+
+	it('clicking a bucket in the drawer closes the drawer', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/', 390);
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /open navigation drawer/i}),
+			).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole('button', {name: /open navigation drawer/i}));
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /go to bucket my-bucket/i}),
+			).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole('button', {name: /go to bucket my-bucket/i}));
+		await waitFor(() => {
+			expect(
+				screen.queryByRole('dialog', {name: /navigation drawer/i}),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it('does not render the desktop sidebar', () => {
+		renderAtWidth('/', 390);
+		expect(screen.queryByRole('navigation', {name: /sidebar/i})).not.toBeInTheDocument();
+	});
+});
+
+describe('AppShell — desktop (1280px)', () => {
+	it('does not render hamburger button on desktop', () => {
+		renderAtWidth('/', 1280);
+		expect(
+			screen.queryByRole('button', {name: /open navigation drawer/i}),
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the desktop sidebar', async () => {
+		renderAtWidth('/', 1280);
+		await waitFor(() => {
+			expect(screen.getByRole('navigation', {name: /sidebar/i})).toBeInTheDocument();
+		});
+	});
+});
+
+describe('BucketListPage — mobile (390px)', () => {
+	it('renders mobile storage card', async () => {
+		renderAtWidth('/', 390);
+		await waitFor(() => {
+			expect(screen.getByText(/storage/i)).toBeInTheDocument();
+		});
+	});
+
+	it('renders bucket rows as mobile list items', async () => {
+		renderAtWidth('/', 390);
+		await waitFor(() => {
+			expect(
+				screen.getByRole('button', {name: /open bucket my-bucket/i}),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole('button', {name: /open bucket another-bucket/i}),
+			).toBeInTheDocument();
+		});
+	});
+});
+
+describe('ObjectBrowser — mobile (390px)', () => {
+	it('renders back button in mobile header', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /go back/i})).toBeInTheDocument();
+		});
+	});
+
+	it('renders List and Grid view toggle buttons', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /list view/i})).toBeInTheDocument();
+			expect(screen.getByRole('button', {name: /grid view/i})).toBeInTheDocument();
+		});
+	});
+
+	it('shows FOLDERS section for folder objects', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText(/folders/i)).toBeInTheDocument();
+		});
+	});
+
+	it('shows FILES section for file objects', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText(/files/i)).toBeInTheDocument();
+		});
+	});
+
+	it('file rows show size on second line', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		expect(screen.getByText(/1\.0 KB/)).toBeInTheDocument();
+	});
+
+	it('mobile file rows have min-height style applied', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		const fileRow = screen
+			.getAllByRole('button')
+			.find((el) => el.textContent?.includes('readme.txt'));
+		expect(fileRow).toBeDefined();
+		expect(fileRow?.style.minHeight).toBe('60px');
+	});
+
+	it('renders mobile upload button', async () => {
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		expect(screen.getByRole('button', {name: /upload/i})).toBeInTheDocument();
+	});
+
+	it('tapping a file opens the inspector', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		await user.click(screen.getByText('readme.txt'));
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /back to file list/i})).toBeInTheDocument();
+		});
+	});
+});
+
+describe('ObjectInspector — mobile (390px)', () => {
+	it('back button closes the inspector', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		await user.click(screen.getByText('readme.txt'));
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /back to file list/i})).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole('button', {name: /back to file list/i}));
+		await waitFor(() => {
+			expect(
+				screen.queryByRole('button', {name: /back to file list/i}),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it('peek sheet shows file metadata', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		await user.click(screen.getByText('readme.txt'));
+		await waitFor(() => {
+			expect(screen.getByText(/size/i)).toBeInTheDocument();
+			expect(screen.getByText(/modified/i)).toBeInTheDocument();
+		});
+	});
+
+	it('shows download button in mobile action bar', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		await user.click(screen.getByText('readme.txt'));
+		await waitFor(() => {
+			expect(screen.getByTestId('download-btn')).toBeInTheDocument();
+		});
+	});
+
+	it('delete shows confirm step before firing', async () => {
+		let deleteCalled = false;
+		server.use(
+			http.delete('/api/buckets/:bucket/object', () => {
+				deleteCalled = true;
+				return HttpResponse.json({ok: true});
+			}),
+		);
+		const user = userEvent.setup();
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('readme.txt')).toBeInTheDocument();
+		});
+		await user.click(screen.getByText('readme.txt'));
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /delete file/i})).toBeInTheDocument();
+		});
+		await user.click(screen.getByRole('button', {name: /delete file/i}));
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /^delete$/i})).toBeInTheDocument();
+		});
+		expect(deleteCalled).toBe(false);
+		await user.click(screen.getByRole('button', {name: /^delete$/i}));
+		await waitFor(() => {
+			expect(deleteCalled).toBe(true);
+		});
+	});
+
+	it('image inspector renders next button when more siblings exist', async () => {
+		const user = userEvent.setup();
+		renderAtWidth('/buckets/my-bucket', 390);
+		await waitFor(() => {
+			expect(screen.getByText('photo.jpg')).toBeInTheDocument();
+		});
+		await user.click(screen.getByText('photo.jpg'));
+		await waitFor(() => {
+			expect(screen.getByRole('button', {name: /next image/i})).toBeInTheDocument();
+		});
+	});
+});

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,7 +1,9 @@
+import {useRef} from 'react';
 import {useMatch, useNavigate} from 'react-router-dom';
 import {Progress, Text, UnstyledButton} from '@mantine/core';
-import {IconFolder} from '@tabler/icons-react';
+import {IconFolder, IconX} from '@tabler/icons-react';
 import {useBuckets} from '../contexts/BucketsContext';
+import {MobileProvider, useMobile} from '../contexts/MobileContext';
 import {formatSize} from '../utils/format';
 
 const sectionLabel: React.CSSProperties = {
@@ -13,11 +15,7 @@ const sectionLabel: React.CSSProperties = {
 	padding: '18px 18px 6px',
 };
 
-interface AppShellProps {
-	children: React.ReactNode;
-}
-
-export const AppShell = ({children}: AppShellProps) => {
+const RailContent = ({onBucketClick}: {onBucketClick?: () => void}) => {
 	const {buckets, statsMap} = useBuckets();
 	const navigate = useNavigate();
 	const match = useMatch('/buckets/:bucket/*');
@@ -46,6 +44,253 @@ export const AppShell = ({children}: AppShellProps) => {
 		}
 		return n.toString();
 	};
+
+	return (
+		<>
+			{/* Buckets */}
+			<div style={sectionLabel}>Buckets</div>
+			<div>
+				{buckets.map((b) => {
+					const stats = statsMap.get(b.name);
+					const count = stats !== undefined ? formatCount(stats.objectCount) : '…';
+					const isActive = b.name === activeBucket;
+					return (
+						<UnstyledButton
+							key={b.name}
+							onClick={() => {
+								void navigate(`/buckets/${encodeURIComponent(b.name)}`);
+								onBucketClick?.();
+							}}
+							aria-label={`Go to bucket ${b.name}`}
+							aria-current={isActive ? 'page' : undefined}
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								width: '100%',
+								padding: '9px 14px 9px 16px',
+								borderLeft: isActive
+									? '2px solid var(--accent)'
+									: '2px solid transparent',
+								background: isActive ? 'var(--accent-dim)' : 'transparent',
+								gap: 6,
+								minHeight: 44,
+							}}
+						>
+							<div
+								style={{display: 'flex', alignItems: 'center', gap: 7, minWidth: 0}}
+							>
+								<IconFolder
+									size={15}
+									style={{
+										color: isActive
+											? 'var(--accent-text)'
+											: 'var(--text-muted)',
+										flexShrink: 0,
+									}}
+								/>
+								<Text
+									truncate
+									style={{
+										fontSize: 14,
+										color: isActive
+											? 'var(--accent-text)'
+											: 'var(--text-primary)',
+										fontWeight: isActive ? 500 : 400,
+									}}
+								>
+									{b.name}
+								</Text>
+							</div>
+							<Text
+								style={{
+									fontSize: 13,
+									color: 'var(--text-muted)',
+									flexShrink: 0,
+									fontFeatureSettings: '"tnum"',
+								}}
+							>
+								{count}
+							</Text>
+						</UnstyledButton>
+					);
+				})}
+			</div>
+
+			{/* Storage */}
+			<div style={{marginTop: 20}}>
+				<div style={sectionLabel}>Storage</div>
+				<div style={{padding: '8px 18px 14px'}}>
+					<Text
+						fw={700}
+						style={{
+							fontFamily: 'var(--font-display)',
+							fontSize: 30,
+							letterSpacing: '-0.02em',
+							color: 'var(--text-primary)',
+							lineHeight: 1.1,
+							fontFeatureSettings: '"tnum"',
+						}}
+					>
+						{formatSize(displaySize)}
+					</Text>
+					<Text
+						style={{
+							fontSize: 13,
+							color: 'var(--text-muted)',
+							marginTop: 4,
+							fontFeatureSettings: '"tnum"',
+						}}
+					>
+						{displayObjects.toLocaleString()} objects · {displayLabel}
+					</Text>
+					<Progress
+						value={
+							displaySize > 0 ? Math.min(100, (displaySize / 1099511627776) * 100) : 0
+						}
+						size={3}
+						color="kgreen"
+						mt={10}
+						styles={{root: {background: 'var(--border-strong)'}}}
+					/>
+				</div>
+			</div>
+
+			<div style={{flex: 1}} />
+		</>
+	);
+};
+
+const MobileDrawer = () => {
+	const {drawerOpen, closeDrawer} = useMobile();
+	const navigate = useNavigate();
+
+	if (!drawerOpen) {
+		return null;
+	}
+
+	return (
+		<>
+			{/* Scrim */}
+			<div
+				aria-hidden="true"
+				onClick={closeDrawer}
+				style={{
+					position: 'fixed',
+					inset: 0,
+					zIndex: 200,
+					background: 'rgba(0,0,0,0.6)',
+				}}
+			/>
+			{/* Drawer panel */}
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-label="Navigation drawer"
+				style={{
+					position: 'fixed',
+					top: 0,
+					left: 0,
+					bottom: 0,
+					width: 280,
+					zIndex: 201,
+					background: 'var(--rail-bg)',
+					borderRight: '1px solid var(--border-color)',
+					display: 'flex',
+					flexDirection: 'column',
+					overflowY: 'auto',
+				}}
+			>
+				{/* Drawer header */}
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'space-between',
+						padding: '16px 16px 16px 18px',
+						borderBottom: '1px solid var(--border-color)',
+					}}
+				>
+					<UnstyledButton
+						onClick={() => {
+							void navigate('/');
+							closeDrawer();
+						}}
+						style={{display: 'flex', alignItems: 'center', gap: 10}}
+					>
+						<img
+							src="/logo.png"
+							alt="kastor"
+							width={28}
+							height={28}
+							style={{borderRadius: 4, flexShrink: 0}}
+						/>
+						<Text
+							fw={650}
+							style={{
+								fontFamily: 'var(--font-display)',
+								fontSize: 17,
+								letterSpacing: '-0.02em',
+								color: 'var(--text-primary)',
+								lineHeight: 1,
+							}}
+						>
+							kastor
+						</Text>
+					</UnstyledButton>
+					<UnstyledButton
+						onClick={closeDrawer}
+						aria-label="Close drawer"
+						style={{
+							color: 'var(--text-muted)',
+							display: 'flex',
+							alignItems: 'center',
+							padding: 8,
+						}}
+					>
+						<IconX size={18} />
+					</UnstyledButton>
+				</div>
+
+				<RailContent onBucketClick={closeDrawer} />
+			</div>
+		</>
+	);
+};
+
+interface AppShellProps {
+	children: React.ReactNode;
+}
+
+const AppShellInner = ({children}: AppShellProps) => {
+	const {isMobile} = useMobile();
+	const navigate = useNavigate();
+
+	if (isMobile) {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					height: '100vh',
+					background: 'var(--bg-base)',
+				}}
+			>
+				<MobileDrawer />
+				<main
+					style={{
+						flex: 1,
+						minHeight: 0,
+						display: 'flex',
+						flexDirection: 'column',
+						overflow: 'hidden',
+					}}
+				>
+					{children}
+				</main>
+			</div>
+		);
+	}
 
 	return (
 		<div style={{display: 'flex', height: '100vh', background: 'var(--bg-base)'}}>
@@ -96,121 +341,7 @@ export const AppShell = ({children}: AppShellProps) => {
 					</Text>
 				</UnstyledButton>
 
-				{/* Buckets */}
-				<div style={sectionLabel}>Buckets</div>
-				<div>
-					{buckets.map((b) => {
-						const stats = statsMap.get(b.name);
-						const count = stats !== undefined ? formatCount(stats.objectCount) : '…';
-						const isActive = b.name === activeBucket;
-						return (
-							<UnstyledButton
-								key={b.name}
-								onClick={() => {
-									void navigate(`/buckets/${encodeURIComponent(b.name)}`);
-								}}
-								aria-label={`Go to bucket ${b.name}`}
-								aria-current={isActive ? 'page' : undefined}
-								style={{
-									display: 'flex',
-									alignItems: 'center',
-									justifyContent: 'space-between',
-									width: '100%',
-									padding: '9px 14px 9px 16px',
-									borderLeft: isActive
-										? '2px solid var(--accent)'
-										: '2px solid transparent',
-									background: isActive ? 'var(--accent-dim)' : 'transparent',
-									gap: 6,
-								}}
-							>
-								<div
-									style={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: 7,
-										minWidth: 0,
-									}}
-								>
-									<IconFolder
-										size={15}
-										style={{
-											color: isActive
-												? 'var(--accent-text)'
-												: 'var(--text-muted)',
-											flexShrink: 0,
-										}}
-									/>
-									<Text
-										truncate
-										style={{
-											fontSize: 14,
-											color: isActive
-												? 'var(--accent-text)'
-												: 'var(--text-primary)',
-											fontWeight: isActive ? 500 : 400,
-										}}
-									>
-										{b.name}
-									</Text>
-								</div>
-								<Text
-									style={{
-										fontSize: 13,
-										color: 'var(--text-muted)',
-										flexShrink: 0,
-										fontFeatureSettings: '"tnum"',
-									}}
-								>
-									{count}
-								</Text>
-							</UnstyledButton>
-						);
-					})}
-				</div>
-
-				{/* Storage */}
-				<div style={{marginTop: 20}}>
-					<div style={sectionLabel}>Storage</div>
-					<div style={{padding: '8px 18px 14px'}}>
-						<Text
-							fw={700}
-							style={{
-								fontFamily: 'var(--font-display)',
-								fontSize: 30,
-								letterSpacing: '-0.02em',
-								color: 'var(--text-primary)',
-								lineHeight: 1.1,
-								fontFeatureSettings: '"tnum"',
-							}}
-						>
-							{formatSize(displaySize)}
-						</Text>
-						<Text
-							style={{
-								fontSize: 13,
-								color: 'var(--text-muted)',
-								marginTop: 4,
-								fontFeatureSettings: '"tnum"',
-							}}
-						>
-							{displayObjects.toLocaleString()} objects · {displayLabel}
-						</Text>
-						<Progress
-							value={
-								displaySize > 0
-									? Math.min(100, (displaySize / 1099511627776) * 100)
-									: 0
-							}
-							size={3}
-							color="kgreen"
-							mt={10}
-							styles={{root: {background: 'var(--border-strong)'}}}
-						/>
-					</div>
-				</div>
-
-				<div style={{flex: 1}} />
+				<RailContent />
 			</nav>
 
 			{/* Main content */}
@@ -225,6 +356,18 @@ export const AppShell = ({children}: AppShellProps) => {
 			>
 				{children}
 			</main>
+		</div>
+	);
+};
+
+export const AppShell = ({children}: AppShellProps) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	return (
+		<div ref={containerRef} style={{height: '100vh'}}>
+			<MobileProvider containerRef={containerRef}>
+				<AppShellInner>{children}</AppShellInner>
+			</MobileProvider>
 		</div>
 	);
 };

--- a/frontend/src/components/ObjectBrowser.tsx
+++ b/frontend/src/components/ObjectBrowser.tsx
@@ -14,6 +14,7 @@ import {
 import {notifications} from '@mantine/notifications';
 import {
 	IconCalculator,
+	IconChevronLeft,
 	IconDownload,
 	IconFile,
 	IconFolder,
@@ -27,6 +28,7 @@ import streamSaver from 'streamsaver';
 import type {S3Object} from '@shared/types';
 import {buildBreadcrumbSegments} from '../utils/breadcrumbs';
 import {formatDate, formatSize} from '../utils/format';
+import {useMobile} from '../contexts/MobileContext';
 import {DragOverlay} from './DragOverlay';
 import {GalleryView} from './GalleryView';
 import {PaginationControls} from './Pagination';
@@ -61,6 +63,7 @@ interface ObjectBrowserProps {
 	folderSizes: Map<string, number>;
 	calculatingFolders: Set<string>;
 	onCalculateFolderSize: (prefix: string) => void;
+	onGoBack?: (() => void) | undefined;
 }
 
 const crumbSep: React.CSSProperties = {
@@ -94,6 +97,15 @@ const iconBtn = (extra: React.CSSProperties = {}): React.CSSProperties => ({
 	...extra,
 });
 
+const mobileSectionLabel: React.CSSProperties = {
+	fontSize: 11,
+	fontWeight: 650,
+	letterSpacing: '0.09em',
+	textTransform: 'uppercase',
+	color: 'var(--text-muted)',
+	padding: '14px 16px 6px',
+};
+
 export const ObjectBrowser = ({
 	bucket,
 	prefix,
@@ -117,7 +129,9 @@ export const ObjectBrowser = ({
 	folderSizes,
 	calculatingFolders,
 	onCalculateFolderSize,
+	onGoBack,
 }: ObjectBrowserProps) => {
+	const {isMobile} = useMobile();
 	const [viewMode, setViewMode] = useState<'table' | 'gallery'>('table');
 	const [filterText, setFilterText] = useState('');
 	const [deleteFolderConfirm, setDeleteFolderConfirm] = useState(false);
@@ -186,6 +200,38 @@ export const ObjectBrowser = ({
 			setDownloadingFolder(false);
 		}
 	};
+
+	if (isMobile) {
+		return (
+			<MobileObjectBrowser
+				bucket={bucket}
+				prefix={prefix}
+				objects={visibleObjects}
+				totalCount={totalCount}
+				loading={loading}
+				page={page}
+				pageSize={pageSize}
+				selectedKey={selectedKey}
+				uploadProgress={uploadProgress}
+				crumbs={crumbs}
+				viewMode={viewMode}
+				filterText={filterText}
+				isDragging={isDragging}
+				dragProps={dragProps}
+				onNavigate={onNavigate}
+				onSelectObject={onSelectObject}
+				onPageChange={onPageChange}
+				onPageSizeChange={onPageSizeChange}
+				onUploadClick={onUploadClick}
+				onSetViewMode={setViewMode}
+				onSetFilterText={setFilterText}
+				onGoBack={onGoBack}
+				folderSizes={folderSizes}
+				calculatingFolders={calculatingFolders}
+				onCalculateFolderSize={onCalculateFolderSize}
+			/>
+		);
+	}
 
 	return (
 		<div
@@ -537,6 +583,518 @@ export const ObjectBrowser = ({
 				)}
 			</div>
 		</div>
+	);
+};
+
+interface MobileObjectBrowserProps {
+	bucket: string;
+	prefix: string;
+	objects: S3Object[];
+	totalCount: number;
+	loading: boolean;
+	page: number;
+	pageSize: number;
+	selectedKey: string | null;
+	uploadProgress: UploadProgress | null;
+	crumbs: Array<{label: string; prefix: string}>;
+	viewMode: 'table' | 'gallery';
+	filterText: string;
+	isDragging: boolean;
+	dragProps: React.HTMLAttributes<HTMLDivElement>;
+	onNavigate: (prefix: string) => void;
+	onSelectObject: (key: string | null) => void;
+	onPageChange: (page: number) => void;
+	onPageSizeChange: (size: number) => void;
+	onUploadClick: () => void;
+	onSetViewMode: (mode: 'table' | 'gallery') => void;
+	onSetFilterText: (text: string) => void;
+	onGoBack?: (() => void) | undefined;
+	folderSizes: Map<string, number>;
+	calculatingFolders: Set<string>;
+	onCalculateFolderSize: (prefix: string) => void;
+}
+
+const MobileObjectBrowser = ({
+	bucket,
+	prefix,
+	objects,
+	totalCount,
+	loading,
+	page,
+	pageSize,
+	selectedKey,
+	uploadProgress,
+	crumbs,
+	viewMode,
+	filterText,
+	isDragging,
+	dragProps,
+	onNavigate,
+	onSelectObject,
+	onPageChange,
+	onPageSizeChange,
+	onUploadClick,
+	onSetViewMode,
+	onSetFilterText,
+	onGoBack,
+	folderSizes,
+	calculatingFolders,
+	onCalculateFolderSize,
+}: MobileObjectBrowserProps) => {
+	const [showFilter, setShowFilter] = useState(false);
+	const filterRef = useRef<HTMLInputElement>(null);
+	const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (focusTimeoutRef.current !== null) {
+				clearTimeout(focusTimeoutRef.current);
+			}
+		};
+	}, []);
+
+	const folders = objects.filter((o) => o.isPrefix);
+	const files = objects.filter((o) => !o.isPrefix);
+
+	const parentLabel = crumbs.length > 1 ? (crumbs[crumbs.length - 2]?.label ?? bucket) : null;
+	const currentLabel = crumbs[crumbs.length - 1]?.label ?? bucket;
+
+	return (
+		<div
+			data-testid="object-browser"
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				height: '100%',
+				position: 'relative',
+				background: 'var(--bg-base)',
+			}}
+			{...dragProps}
+		>
+			<DragOverlay show={isDragging} />
+
+			{/* Mobile top header */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					padding: '0 8px 0 4px',
+					height: 56,
+					borderBottom: '1px solid var(--border-color)',
+					background: 'var(--bg-base)',
+					flexShrink: 0,
+				}}
+			>
+				<button
+					onClick={
+						prefix !== ''
+							? () => onNavigate(crumbs[crumbs.length - 2]?.prefix ?? '')
+							: (onGoBack ?? undefined)
+					}
+					aria-label="Go back"
+					style={{
+						background: 'none',
+						border: 'none',
+						cursor: 'pointer',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						minWidth: 44,
+						minHeight: 44,
+						color: 'var(--accent-text)',
+						flexShrink: 0,
+					}}
+				>
+					<IconChevronLeft size={22} />
+				</button>
+
+				<div style={{flex: 1, minWidth: 0}}>
+					<Text
+						fw={600}
+						truncate
+						style={{
+							fontFamily: 'var(--font-display)',
+							fontSize: 15,
+							color: 'var(--text-primary)',
+							lineHeight: 1.2,
+						}}
+					>
+						{bucket}
+					</Text>
+					{prefix !== '' && (
+						<Text
+							truncate
+							style={{
+								fontSize: 12,
+								color: 'var(--text-muted)',
+								lineHeight: 1.2,
+							}}
+						>
+							{parentLabel !== null && parentLabel !== bucket
+								? `${parentLabel} / ${currentLabel}`
+								: currentLabel}
+						</Text>
+					)}
+				</div>
+
+				<button
+					onClick={() => {
+						setShowFilter((v) => !v);
+						if (focusTimeoutRef.current !== null) {
+							clearTimeout(focusTimeoutRef.current);
+						}
+						focusTimeoutRef.current = setTimeout(() => filterRef.current?.focus(), 50);
+					}}
+					aria-label="Toggle search"
+					style={{
+						background: 'none',
+						border: 'none',
+						cursor: 'pointer',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						minWidth: 44,
+						minHeight: 44,
+						color: 'var(--text-muted)',
+						flexShrink: 0,
+					}}
+				>
+					<IconSearch size={18} />
+				</button>
+			</div>
+
+			{/* Filter bar (when shown) */}
+			{showFilter && (
+				<div
+					style={{
+						padding: '8px 12px',
+						background: 'var(--bg-base)',
+						borderBottom: '1px solid var(--border-color)',
+					}}
+				>
+					<TextInput
+						ref={filterRef}
+						size="sm"
+						placeholder="Filter files…"
+						leftSection={<IconSearch size={13} />}
+						value={filterText}
+						onChange={(e) => {
+							onSetFilterText(e.currentTarget.value);
+						}}
+						styles={{
+							input: {
+								background: 'var(--bg-surface)',
+								border: '1px solid var(--border-color)',
+								color: 'var(--text-primary)',
+								fontSize: 14,
+							},
+						}}
+						aria-label="Filter visible"
+					/>
+				</div>
+			)}
+
+			{/* View toggle + count bar */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					padding: '8px 16px',
+					borderBottom: '1px solid var(--border-color)',
+					background: 'var(--bg-base)',
+					flexShrink: 0,
+				}}
+			>
+				<div style={{display: 'flex', gap: 4}}>
+					<button
+						onClick={() => {
+							onSetViewMode('table');
+						}}
+						aria-label="List view"
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 5,
+							padding: '6px 12px',
+							border: '1px solid var(--border-color)',
+							borderRadius: 6,
+							cursor: 'pointer',
+							background: viewMode === 'table' ? 'var(--accent-dim)' : 'transparent',
+							color:
+								viewMode === 'table' ? 'var(--accent-text)' : 'var(--text-muted)',
+							fontSize: 13,
+							fontWeight: viewMode === 'table' ? 500 : 400,
+							minHeight: 36,
+						}}
+					>
+						<IconList size={14} />
+						List
+					</button>
+					<button
+						onClick={() => {
+							onSetViewMode('gallery');
+						}}
+						aria-label="Grid view"
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 5,
+							padding: '6px 12px',
+							border: '1px solid var(--border-color)',
+							borderRadius: 6,
+							cursor: 'pointer',
+							background:
+								viewMode === 'gallery' ? 'var(--accent-dim)' : 'transparent',
+							color:
+								viewMode === 'gallery' ? 'var(--accent-text)' : 'var(--text-muted)',
+							fontSize: 13,
+							fontWeight: viewMode === 'gallery' ? 500 : 400,
+							minHeight: 36,
+						}}
+					>
+						<IconLayoutGrid size={14} />
+						Grid
+					</button>
+				</div>
+				<Text style={{fontSize: 13, color: 'var(--text-muted)'}}>
+					{loading ? '…' : `${totalCount} items`}
+				</Text>
+			</div>
+
+			{/* Upload progress */}
+			{uploadProgress !== null && (
+				<div
+					style={{
+						padding: '5px 16px',
+						background: 'var(--bg-surface)',
+						borderBottom: '1px solid var(--border-color)',
+						fontSize: 13,
+						color: 'var(--text-muted)',
+					}}
+				>
+					Uploading {uploadProgress.filename} ({uploadProgress.done + 1}/
+					{uploadProgress.total}) {uploadProgress.fileProgress}%
+				</div>
+			)}
+
+			{/* Scrollable content */}
+			<div style={{flex: 1, overflowY: 'auto', paddingBottom: 80}}>
+				{loading && (
+					<Stack gap={0} p={0}>
+						{[1, 2, 3, 4, 5, 6].map((n) => (
+							<Skeleton key={n} height={60} radius={0} style={{marginBottom: 1}} />
+						))}
+					</Stack>
+				)}
+
+				{!loading && objects.length === 0 && (
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							alignItems: 'center',
+							justifyContent: 'center',
+							padding: '80px 40px',
+							gap: 14,
+						}}
+					>
+						<IconFolder size={48} style={{color: 'var(--text-muted)'}} />
+						<Text style={{color: 'var(--text-muted)', fontSize: 15}}>
+							{filterText ? 'No matches for your filter' : 'This folder is empty'}
+						</Text>
+					</div>
+				)}
+
+				{!loading && objects.length > 0 && viewMode === 'gallery' && (
+					<div style={{padding: 12}}>
+						<GalleryView
+							objects={objects}
+							bucket={bucket}
+							prefix={prefix}
+							onNavigate={onNavigate}
+							onSelectObject={onSelectObject}
+						/>
+					</div>
+				)}
+
+				{!loading && objects.length > 0 && viewMode === 'table' && (
+					<>
+						{folders.length > 0 && (
+							<>
+								<div style={mobileSectionLabel}>Folders</div>
+								{folders.map((obj) => (
+									<MobileFolderRow
+										key={obj.key}
+										obj={obj}
+										prefix={prefix}
+										onNavigate={onNavigate}
+									/>
+								))}
+							</>
+						)}
+
+						{files.length > 0 && (
+							<>
+								<div style={mobileSectionLabel}>Files</div>
+								{files.map((obj) => (
+									<MobileFileRow
+										key={obj.key}
+										obj={obj}
+										prefix={prefix}
+										isSelected={obj.key === selectedKey}
+										onSelectObject={onSelectObject}
+									/>
+								))}
+							</>
+						)}
+					</>
+				)}
+
+				{!loading && (
+					<div style={{padding: '8px 16px'}}>
+						<PaginationControls
+							page={page}
+							totalCount={totalCount}
+							pageSize={pageSize}
+							onPageChange={onPageChange}
+							onPageSizeChange={onPageSizeChange}
+						/>
+					</div>
+				)}
+			</div>
+
+			{/* Sticky upload button */}
+			<div
+				style={{
+					position: 'absolute',
+					bottom: 0,
+					left: 0,
+					right: 0,
+					padding: '10px 16px',
+					background: 'var(--bg-base)',
+					borderTop: '1px solid var(--border-color)',
+				}}
+			>
+				<Button
+					leftSection={<IconUpload size={16} />}
+					variant="filled"
+					color="kgreen"
+					onClick={onUploadClick}
+					disabled={uploadProgress !== null}
+					fullWidth
+					style={{height: 48, fontSize: 15}}
+				>
+					Upload
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+interface MobileFolderRowProps {
+	obj: S3Object;
+	prefix: string;
+	onNavigate: (p: string) => void;
+}
+
+const MobileFolderRow = ({obj, prefix, onNavigate}: MobileFolderRowProps) => {
+	const name = obj.key.slice(prefix.length).replace(/\/$/, '');
+	return (
+		<button
+			onClick={() => {
+				onNavigate(obj.key);
+			}}
+			aria-label={`Open folder ${name}`}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 12,
+				width: '100%',
+				padding: '0 16px',
+				minHeight: 56,
+				background: 'none',
+				border: 'none',
+				borderBottom: '1px solid var(--border-color)',
+				cursor: 'pointer',
+				textAlign: 'left',
+			}}
+		>
+			<IconFolder size={18} style={{color: 'var(--text-muted)', flexShrink: 0}} />
+			<Text
+				truncate
+				style={{
+					flex: 1,
+					fontSize: 15,
+					color: 'var(--text-primary)',
+					minWidth: 0,
+				}}
+			>
+				{name}
+			</Text>
+			<span style={{color: 'var(--text-muted)', fontSize: 18, flexShrink: 0}}>›</span>
+		</button>
+	);
+};
+
+interface MobileFileRowProps {
+	obj: S3Object;
+	prefix: string;
+	isSelected: boolean;
+	onSelectObject: (key: string | null) => void;
+}
+
+const MobileFileRow = ({obj, prefix, isSelected, onSelectObject}: MobileFileRowProps) => {
+	const name = obj.key.slice(prefix.length);
+	const rowBg = isSelected ? 'var(--accent-dim)' : 'transparent';
+
+	return (
+		<button
+			onClick={() => {
+				onSelectObject(isSelected ? null : obj.key);
+			}}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 12,
+				width: '100%',
+				padding: '0 16px',
+				minHeight: 60,
+				background: rowBg,
+				border: 'none',
+				borderBottom: '1px solid var(--border-color)',
+				boxShadow: isSelected ? 'inset 2px 0 0 var(--accent)' : undefined,
+				cursor: 'pointer',
+				textAlign: 'left',
+			}}
+		>
+			<IconFile size={18} style={{color: 'var(--text-muted)', flexShrink: 0}} />
+			<div style={{flex: 1, minWidth: 0}}>
+				<Text
+					truncate
+					style={{
+						fontFamily: 'var(--font-display)',
+						fontSize: 14,
+						color: 'var(--text-primary)',
+						lineHeight: 1.3,
+					}}
+				>
+					{name}
+				</Text>
+				<Text
+					style={{
+						fontSize: 12,
+						color: 'var(--text-muted)',
+						marginTop: 2,
+						fontFeatureSettings: '"tnum"',
+					}}
+				>
+					{formatSize(obj.size)} ·{' '}
+					{obj.lastModified !== '' ? formatDate(obj.lastModified) : '—'}
+				</Text>
+			</div>
+		</button>
 	);
 };
 

--- a/frontend/src/components/ObjectInspector.tsx
+++ b/frontend/src/components/ObjectInspector.tsx
@@ -13,6 +13,8 @@ import {
 import type {S3Object} from '@shared/types';
 import {isImageFile} from '../utils/imageUtils';
 import {formatDate, formatSize} from '../utils/format';
+import {useMobile} from '../contexts/MobileContext';
+import {useSwipe} from '../hooks/useSwipe';
 
 const objectUrl = (bucket: string, key: string): string =>
 	`/api/buckets/${encodeURIComponent(bucket)}/object?key=${encodeURIComponent(key)}`;
@@ -329,6 +331,7 @@ export const ObjectInspector = ({
 	onDelete,
 	onNavigate,
 }: ObjectInspectorProps) => {
+	const {isMobile} = useMobile();
 	const [imgLoaded, setImgLoaded] = useState(false);
 	const isImage = isImageFile(objectKey);
 	const filename = objectKey.split('/').pop() ?? objectKey;
@@ -346,6 +349,29 @@ export const ObjectInspector = ({
 		onClose,
 		onDeleteDone: onDelete,
 	};
+
+	if (isMobile) {
+		return (
+			<MobileInspector
+				bucket={bucket}
+				objectKey={objectKey}
+				size={size}
+				lastModified={lastModified}
+				contentType={contentType}
+				filename={filename}
+				isImage={isImage}
+				imgLoaded={imgLoaded}
+				imageSiblings={imageSiblings}
+				currentIdx={currentIdx}
+				onClose={onClose}
+				onDelete={onDelete}
+				onNavigate={onNavigate}
+				onImgLoad={() => {
+					setImgLoaded(true);
+				}}
+			/>
+		);
+	}
 
 	if (isImage) {
 		return (
@@ -504,7 +530,7 @@ export const ObjectInspector = ({
 										background: 'var(--bg-base)',
 									}}
 									aria-label={`Go to ${sib.key.split('/').pop()}`}
-									aria-current={i === currentIdx ? 'true' : undefined}
+									aria-current={i === currentIdx ? true : undefined}
 								>
 									<img
 										src={objectUrl(bucket, sib.key)}
@@ -548,6 +574,484 @@ export const ObjectInspector = ({
 				</Text>
 			</div>
 			<InspectorRail {...railProps} />
+		</div>
+	);
+};
+
+interface MobileInspectorProps {
+	bucket: string;
+	objectKey: string;
+	size: number;
+	lastModified: string;
+	contentType: string | undefined;
+	filename: string;
+	isImage: boolean;
+	imgLoaded: boolean;
+	imageSiblings: S3Object[];
+	currentIdx: number;
+	onClose: () => void;
+	onDelete: (key: string) => void;
+	onNavigate: (key: string) => void;
+	onImgLoad: () => void;
+}
+
+const MobileInspector = ({
+	bucket,
+	objectKey,
+	size,
+	lastModified,
+	contentType,
+	filename,
+	isImage,
+	imgLoaded,
+	imageSiblings,
+	currentIdx,
+	onClose,
+	onDelete,
+	onNavigate,
+	onImgLoad,
+}: MobileInspectorProps) => {
+	const [deleteConfirm, setDeleteConfirm] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+	const directUrl = `${window.location.origin}${objectUrl(bucket, objectKey)}`;
+
+	const goToPrev = () => {
+		const prev = imageSiblings[currentIdx - 1];
+		if (prev !== undefined) {
+			onNavigate(prev.key);
+		}
+	};
+
+	const goToNext = () => {
+		const next = imageSiblings[currentIdx + 1];
+		if (next !== undefined) {
+			onNavigate(next.key);
+		}
+	};
+
+	const swipeHandlers = useSwipe({
+		onSwipeLeft: currentIdx < imageSiblings.length - 1 ? goToNext : undefined,
+		onSwipeRight: currentIdx > 0 ? goToPrev : undefined,
+	});
+
+	const confirmDelete = async () => {
+		setDeleting(true);
+		try {
+			const url = `/api/buckets/${encodeURIComponent(bucket)}/object?key=${encodeURIComponent(objectKey)}`;
+			const res = await fetch(url, {method: 'DELETE'});
+			if (!res.ok) {
+				throw new Error(`Delete failed: ${res.status}`);
+			}
+			onDelete(objectKey);
+		} catch (err) {
+			notifications.show({
+				title: 'Failed to delete',
+				message: err instanceof Error ? err.message : 'Unknown error',
+				color: 'red',
+			});
+		} finally {
+			setDeleting(false);
+			setDeleteConfirm(false);
+		}
+	};
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				width: '100%',
+				height: '100%',
+				background: isImage ? '#000' : 'var(--bg-base)',
+			}}
+		>
+			{/* Mobile header */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					padding: '0 8px 0 4px',
+					height: 56,
+					borderBottom: '1px solid rgba(255,255,255,0.08)',
+					background: isImage ? 'rgba(0,0,0,0.7)' : 'var(--bg-base)',
+					flexShrink: 0,
+					zIndex: 1,
+				}}
+			>
+				<button
+					onClick={onClose}
+					aria-label="Back to file list"
+					style={{
+						background: 'none',
+						border: 'none',
+						cursor: 'pointer',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						minWidth: 44,
+						minHeight: 44,
+						color: isImage ? 'rgba(255,255,255,0.9)' : 'var(--accent-text)',
+						flexShrink: 0,
+					}}
+				>
+					<IconChevronLeft size={22} />
+				</button>
+				<Text
+					fw={500}
+					truncate
+					style={{
+						flex: 1,
+						fontFamily: 'var(--font-display)',
+						fontSize: 15,
+						color: isImage ? 'rgba(255,255,255,0.9)' : 'var(--text-primary)',
+					}}
+				>
+					{filename}
+				</Text>
+			</div>
+
+			{/* Content area */}
+			{isImage ? (
+				<div
+					style={{
+						flex: 1,
+						position: 'relative',
+						overflow: 'hidden',
+						minHeight: 0,
+					}}
+					{...swipeHandlers}
+				>
+					{!imgLoaded && (
+						<>
+							<Skeleton
+								style={{
+									position: 'absolute',
+									inset: 0,
+									width: '100%',
+									height: '100%',
+									zIndex: 1,
+									background: '#1a1a1a',
+								}}
+							/>
+							<Text
+								{...LOADING_TEXT_VARIANTS[LOADING_TEXT_STYLE]}
+								style={{
+									...loadingTextBase,
+									color: 'rgba(255,255,255,0.5)',
+								}}
+							>
+								kastor is purring...
+							</Text>
+						</>
+					)}
+					<img
+						key={objectKey}
+						src={objectUrl(bucket, objectKey)}
+						alt={filename}
+						style={{
+							position: 'absolute',
+							inset: 0,
+							width: '100%',
+							height: '100%',
+							objectFit: 'contain',
+						}}
+						onLoad={onImgLoad}
+						onError={onImgLoad}
+					/>
+
+					{/* Prev/Next buttons */}
+					{currentIdx > 0 && (
+						<button
+							onClick={goToPrev}
+							aria-label="Previous image"
+							style={{
+								position: 'absolute',
+								left: 12,
+								top: '50%',
+								transform: 'translateY(-50%)',
+								width: 48,
+								height: 48,
+								borderRadius: 24,
+								background: 'rgba(0,0,0,0.5)',
+								border: 'none',
+								cursor: 'pointer',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								color: '#fff',
+							}}
+						>
+							<IconChevronLeft size={22} />
+						</button>
+					)}
+					{currentIdx < imageSiblings.length - 1 && (
+						<button
+							onClick={goToNext}
+							aria-label="Next image"
+							style={{
+								position: 'absolute',
+								right: 12,
+								top: '50%',
+								transform: 'translateY(-50%)',
+								width: 48,
+								height: 48,
+								borderRadius: 24,
+								background: 'rgba(0,0,0,0.5)',
+								border: 'none',
+								cursor: 'pointer',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								color: '#fff',
+							}}
+						>
+							<IconChevronRight size={22} />
+						</button>
+					)}
+				</div>
+			) : (
+				<div
+					style={{
+						flex: 1,
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'center',
+						justifyContent: 'center',
+						gap: 12,
+					}}
+				>
+					<IconFile size={64} style={{color: 'var(--text-muted)'}} />
+					<Text c="dimmed" size="sm">
+						{filename}
+					</Text>
+				</div>
+			)}
+
+			{/* Peek sheet */}
+			<div
+				style={{
+					background: isImage ? 'rgba(10,10,10,0.95)' : 'var(--bg-surface)',
+					borderTop: '1px solid rgba(255,255,255,0.08)',
+					flexShrink: 0,
+				}}
+			>
+				{/* Metadata row */}
+				<div
+					style={{
+						display: 'flex',
+						borderBottom: '1px solid rgba(255,255,255,0.06)',
+					}}
+				>
+					<div
+						style={{
+							flex: 1,
+							padding: '10px 16px',
+							borderRight: '1px solid rgba(255,255,255,0.06)',
+						}}
+					>
+						<Text
+							style={{
+								fontSize: 10,
+								fontWeight: 650,
+								letterSpacing: '0.08em',
+								textTransform: 'uppercase',
+								color: 'rgba(255,255,255,0.4)',
+								marginBottom: 3,
+							}}
+						>
+							Size
+						</Text>
+						<Text
+							style={{
+								fontSize: 13,
+								color: isImage ? 'rgba(255,255,255,0.85)' : 'var(--text-primary)',
+								fontFeatureSettings: '"tnum"',
+							}}
+						>
+							{formatSize(size)}
+						</Text>
+					</div>
+					<div
+						style={{
+							flex: 1,
+							padding: '10px 16px',
+							borderRight: '1px solid rgba(255,255,255,0.06)',
+						}}
+					>
+						<Text
+							style={{
+								fontSize: 10,
+								fontWeight: 650,
+								letterSpacing: '0.08em',
+								textTransform: 'uppercase',
+								color: 'rgba(255,255,255,0.4)',
+								marginBottom: 3,
+							}}
+						>
+							Type
+						</Text>
+						<Text
+							style={{
+								fontSize: 13,
+								color: isImage ? 'rgba(255,255,255,0.85)' : 'var(--text-primary)',
+							}}
+						>
+							{contentType?.split('/')[1]?.toUpperCase() ??
+								filename.split('.').pop()?.toUpperCase() ??
+								'—'}
+						</Text>
+					</div>
+					<div style={{flex: 1, padding: '10px 16px'}}>
+						<Text
+							style={{
+								fontSize: 10,
+								fontWeight: 650,
+								letterSpacing: '0.08em',
+								textTransform: 'uppercase',
+								color: 'rgba(255,255,255,0.4)',
+								marginBottom: 3,
+							}}
+						>
+							Modified
+						</Text>
+						<Text
+							style={{
+								fontSize: 13,
+								color: isImage ? 'rgba(255,255,255,0.85)' : 'var(--text-primary)',
+								fontFeatureSettings: '"tnum"',
+							}}
+						>
+							{lastModified !== '' ? formatDate(lastModified) : '—'}
+						</Text>
+					</div>
+				</div>
+
+				{/* Action bar */}
+				{!deleteConfirm ? (
+					<div
+						style={{
+							display: 'flex',
+							height: 56,
+							paddingBottom: 'env(safe-area-inset-bottom)',
+						}}
+					>
+						<CopyButton value={directUrl}>
+							{({copied, copy}) => (
+								<button
+									onClick={copy}
+									style={{
+										flex: 1,
+										background: 'none',
+										border: 'none',
+										borderRight: '1px solid rgba(255,255,255,0.06)',
+										cursor: 'pointer',
+										display: 'flex',
+										alignItems: 'center',
+										justifyContent: 'center',
+										gap: 6,
+										color: copied
+											? 'var(--accent-text)'
+											: isImage
+												? 'rgba(255,255,255,0.8)'
+												: 'var(--text-primary)',
+										fontSize: 14,
+									}}
+								>
+									<IconCopy size={16} />
+									{copied ? 'Copied!' : 'Copy link'}
+								</button>
+							)}
+						</CopyButton>
+						<a
+							href={downloadUrl(bucket, objectKey)}
+							download={filename}
+							data-testid="download-btn"
+							style={{
+								flex: 1,
+								background: 'var(--accent)',
+								border: 'none',
+								borderRight: '1px solid rgba(255,255,255,0.06)',
+								cursor: 'pointer',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								gap: 6,
+								color: '#fff',
+								fontSize: 14,
+								textDecoration: 'none',
+								fontWeight: 500,
+							}}
+						>
+							<IconDownload size={16} />
+							Download
+						</a>
+						<button
+							onClick={() => {
+								setDeleteConfirm(true);
+							}}
+							aria-label="Delete file"
+							style={{
+								width: 56,
+								background: 'none',
+								border: 'none',
+								cursor: 'pointer',
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'center',
+								color: 'var(--danger)',
+							}}
+						>
+							<IconTrash size={18} />
+						</button>
+					</div>
+				) : (
+					<div
+						style={{
+							padding: '10px 16px',
+							paddingBottom: 'calc(10px + env(safe-area-inset-bottom))',
+						}}
+					>
+						<Text
+							style={{
+								fontSize: 13,
+								color: isImage ? 'rgba(255,255,255,0.7)' : 'var(--text-muted)',
+								marginBottom: 10,
+							}}
+						>
+							Delete{' '}
+							<strong style={{color: isImage ? '#fff' : 'var(--text-primary)'}}>
+								{filename}
+							</strong>
+							? This cannot be undone.
+						</Text>
+						<div style={{display: 'flex', gap: 8}}>
+							<Button
+								color="red"
+								size="sm"
+								loading={deleting}
+								onClick={() => {
+									void confirmDelete();
+								}}
+								style={{flex: 1}}
+							>
+								Delete
+							</Button>
+							<Button
+								variant="default"
+								size="sm"
+								disabled={deleting}
+								onClick={() => {
+									setDeleteConfirm(false);
+								}}
+								style={{flex: 1}}
+							>
+								Cancel
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
 		</div>
 	);
 };

--- a/frontend/src/contexts/MobileContext.tsx
+++ b/frontend/src/contexts/MobileContext.tsx
@@ -1,0 +1,57 @@
+import {createContext, useCallback, useContext, useEffect, useState} from 'react';
+
+interface MobileContextValue {
+	isMobile: boolean;
+	drawerOpen: boolean;
+	openDrawer: () => void;
+	closeDrawer: () => void;
+}
+
+const MobileContext = createContext<MobileContextValue>({
+	isMobile: false,
+	drawerOpen: false,
+	openDrawer: () => {},
+	closeDrawer: () => {},
+});
+
+export const useMobile = () => useContext(MobileContext);
+
+export const MobileProvider = ({
+	containerRef,
+	children,
+}: {
+	containerRef: React.RefObject<HTMLDivElement | null>;
+	children: React.ReactNode;
+}) => {
+	const [isMobile, setIsMobile] = useState(false);
+	const [drawerOpen, setDrawerOpen] = useState(false);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (el === null) {
+			return;
+		}
+		const observer = new ResizeObserver(([entry]) => {
+			if (entry !== undefined) {
+				setIsMobile(entry.contentRect.width <= 640);
+			}
+		});
+		observer.observe(el);
+		return () => {
+			observer.disconnect();
+		};
+	}, [containerRef]);
+
+	const openDrawer = useCallback(() => {
+		setDrawerOpen(true);
+	}, []);
+	const closeDrawer = useCallback(() => {
+		setDrawerOpen(false);
+	}, []);
+
+	return (
+		<MobileContext.Provider value={{isMobile, drawerOpen, openDrawer, closeDrawer}}>
+			{children}
+		</MobileContext.Provider>
+	);
+};

--- a/frontend/src/hooks/useSwipe.ts
+++ b/frontend/src/hooks/useSwipe.ts
@@ -1,0 +1,34 @@
+import {useCallback, useRef} from 'react';
+
+interface UseSwipeOptions {
+	onSwipeLeft?: (() => void) | undefined;
+	onSwipeRight?: (() => void) | undefined;
+	threshold?: number;
+}
+
+export const useSwipe = ({onSwipeLeft, onSwipeRight, threshold = 50}: UseSwipeOptions) => {
+	const startX = useRef<number | null>(null);
+
+	const onTouchStart = useCallback((e: React.TouchEvent) => {
+		startX.current = e.touches[0]?.clientX ?? null;
+	}, []);
+
+	const onTouchEnd = useCallback(
+		(e: React.TouchEvent) => {
+			if (startX.current === null) {
+				return;
+			}
+			const endX = e.changedTouches[0]?.clientX ?? startX.current;
+			const delta = endX - startX.current;
+			startX.current = null;
+			if (delta < -threshold) {
+				onSwipeLeft?.();
+			} else if (delta > threshold) {
+				onSwipeRight?.();
+			}
+		},
+		[onSwipeLeft, onSwipeRight, threshold],
+	);
+
+	return {onTouchStart, onTouchEnd};
+};

--- a/frontend/src/pages/BucketListPage.tsx
+++ b/frontend/src/pages/BucketListPage.tsx
@@ -1,8 +1,9 @@
 import {useNavigate} from 'react-router-dom';
-import {Skeleton, Text} from '@mantine/core';
-import {IconFolder} from '@tabler/icons-react';
+import {Progress, Skeleton, Text, UnstyledButton} from '@mantine/core';
+import {IconFolder, IconMenu2} from '@tabler/icons-react';
 import type {Bucket, BucketStats} from '@shared/types';
 import {useBuckets} from '../contexts/BucketsContext';
+import {useMobile} from '../contexts/MobileContext';
 import {formatDate, formatSize} from '../utils/format';
 
 interface BucketCardProps {
@@ -30,7 +31,7 @@ const statValue: React.CSSProperties = {
 	lineHeight: 1,
 };
 
-const BucketCard = ({bucket, stats, statsLoading, onClick}: BucketCardProps) => (
+const DesktopBucketCard = ({bucket, stats, statsLoading, onClick}: BucketCardProps) => (
 	<button
 		onClick={onClick}
 		aria-label={`Open bucket ${bucket.name}`}
@@ -144,9 +145,232 @@ const BucketCard = ({bucket, stats, statsLoading, onClick}: BucketCardProps) => 
 	</button>
 );
 
+const MobileBucketRow = ({bucket, stats, statsLoading, onClick}: BucketCardProps) => (
+	<UnstyledButton
+		onClick={onClick}
+		aria-label={`Open bucket ${bucket.name}`}
+		style={{
+			display: 'flex',
+			alignItems: 'center',
+			gap: 12,
+			padding: '14px 16px',
+			background: 'var(--bg-surface)',
+			border: '1px solid var(--border-color)',
+			borderRadius: 10,
+			width: '100%',
+			minHeight: 56,
+		}}
+	>
+		<div
+			style={{
+				width: 40,
+				height: 40,
+				borderRadius: 8,
+				background: 'var(--accent-dim)',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				flexShrink: 0,
+			}}
+		>
+			<IconFolder size={20} style={{color: 'var(--accent-text)'}} />
+		</div>
+		<div style={{flex: 1, minWidth: 0}}>
+			<Text
+				fw={600}
+				truncate
+				style={{fontSize: 15, color: 'var(--text-primary)', lineHeight: 1.3}}
+			>
+				{bucket.name}
+			</Text>
+			<Text style={{fontSize: 13, color: 'var(--text-muted)', marginTop: 2}}>
+				{statsLoading
+					? '…'
+					: stats !== undefined
+						? `${stats.objectCount.toLocaleString()} objects · ${formatSize(stats.totalSize)}`
+						: '—'}
+			</Text>
+		</div>
+		<span style={{color: 'var(--text-muted)', fontSize: 18, flexShrink: 0}}>›</span>
+	</UnstyledButton>
+);
+
+const MobileBucketListPage = () => {
+	const navigate = useNavigate();
+	const {buckets, statsMap, bucketsLoading} = useBuckets();
+	const {openDrawer} = useMobile();
+
+	const totalObjects = buckets.reduce(
+		(sum, b) => sum + (statsMap.get(b.name)?.objectCount ?? 0),
+		0,
+	);
+	const totalSize = buckets.reduce((sum, b) => sum + (statsMap.get(b.name)?.totalSize ?? 0), 0);
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				height: '100%',
+				background: 'var(--bg-base)',
+			}}
+		>
+			{/* Mobile top header */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					padding: '0 16px',
+					height: 56,
+					borderBottom: '1px solid var(--border-color)',
+					background: 'var(--bg-base)',
+					flexShrink: 0,
+				}}
+			>
+				<UnstyledButton
+					onClick={openDrawer}
+					aria-label="Open navigation drawer"
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						minWidth: 44,
+						minHeight: 44,
+						color: 'var(--text-primary)',
+					}}
+				>
+					<IconMenu2 size={22} />
+				</UnstyledButton>
+				<Text
+					fw={650}
+					style={{
+						fontFamily: 'var(--font-display)',
+						fontSize: 18,
+						letterSpacing: '-0.02em',
+						color: 'var(--text-primary)',
+					}}
+				>
+					kastor
+				</Text>
+				<div style={{width: 44}} />
+			</div>
+
+			{/* Scrollable content */}
+			<div style={{flex: 1, overflowY: 'auto', padding: '16px 16px 24px'}}>
+				{/* Storage card */}
+				<div
+					style={{
+						background: 'var(--bg-surface)',
+						border: '1px solid var(--border-color)',
+						borderRadius: 12,
+						padding: '16px 20px',
+						marginBottom: 24,
+					}}
+				>
+					<Text
+						style={{
+							fontSize: 11,
+							fontWeight: 650,
+							letterSpacing: '0.09em',
+							textTransform: 'uppercase',
+							color: 'var(--accent-text)',
+							marginBottom: 8,
+						}}
+					>
+						Storage
+					</Text>
+					<Text
+						fw={700}
+						style={{
+							fontFamily: 'var(--font-display)',
+							fontSize: 36,
+							letterSpacing: '-0.02em',
+							color: 'var(--text-primary)',
+							lineHeight: 1,
+							fontFeatureSettings: '"tnum"',
+						}}
+					>
+						{formatSize(totalSize)}
+					</Text>
+					<Text
+						style={{
+							fontSize: 13,
+							color: 'var(--text-muted)',
+							marginTop: 4,
+							fontFeatureSettings: '"tnum"',
+						}}
+					>
+						{totalObjects.toLocaleString()} objects · {buckets.length}{' '}
+						{buckets.length === 1 ? 'bucket' : 'buckets'}
+					</Text>
+					<Progress
+						value={totalSize > 0 ? Math.min(100, (totalSize / 1099511627776) * 100) : 0}
+						size={3}
+						color="kgreen"
+						mt={12}
+						styles={{root: {background: 'var(--border-strong)'}}}
+					/>
+				</div>
+
+				{/* Buckets section */}
+				<Text
+					style={{
+						fontSize: 11,
+						fontWeight: 650,
+						letterSpacing: '0.09em',
+						textTransform: 'uppercase',
+						color: 'var(--text-muted)',
+						marginBottom: 12,
+					}}
+				>
+					Buckets
+				</Text>
+
+				{bucketsLoading ? (
+					<div style={{display: 'flex', flexDirection: 'column', gap: 10}}>
+						{[1, 2, 3].map((n) => (
+							<Skeleton key={n} height={72} radius={10} />
+						))}
+					</div>
+				) : buckets.length === 0 ? (
+					<div style={{padding: '60px 0', textAlign: 'center'}}>
+						<IconFolder
+							size={48}
+							style={{color: 'var(--text-muted)', marginBottom: 12}}
+						/>
+						<Text style={{color: 'var(--text-muted)', fontSize: 15}}>
+							No buckets found
+						</Text>
+					</div>
+				) : (
+					<div style={{display: 'flex', flexDirection: 'column', gap: 10}}>
+						{buckets.map((bucket) => (
+							<MobileBucketRow
+								key={bucket.name}
+								bucket={bucket}
+								stats={statsMap.get(bucket.name)}
+								statsLoading={!statsMap.has(bucket.name)}
+								onClick={() => {
+									void navigate(`/buckets/${encodeURIComponent(bucket.name)}`);
+								}}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+};
+
 export const BucketListPage = () => {
 	const navigate = useNavigate();
 	const {buckets, statsMap, bucketsLoading} = useBuckets();
+	const {isMobile} = useMobile();
+
+	if (isMobile) {
+		return <MobileBucketListPage />;
+	}
 
 	if (bucketsLoading) {
 		return (
@@ -226,7 +450,7 @@ export const BucketListPage = () => {
 						}}
 					>
 						{buckets.map((bucket) => (
-							<BucketCard
+							<DesktopBucketCard
 								key={bucket.name}
 								bucket={bucket}
 								stats={statsMap.get(bucket.name)}

--- a/frontend/src/pages/ObjectBrowserPage.tsx
+++ b/frontend/src/pages/ObjectBrowserPage.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
-import {useParams, useSearchParams} from 'react-router-dom';
+import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
 import {Progress, Stack, Text} from '@mantine/core';
 import {notifications} from '@mantine/notifications';
 import streamSaver from 'streamsaver';
@@ -15,6 +15,7 @@ import {
 import {ObjectBrowser} from '../components/ObjectBrowser';
 import {ObjectInspector} from '../components/ObjectInspector';
 import {useDragUpload} from '../hooks/useDragUpload';
+import {useMobile} from '../contexts/MobileContext';
 import type {ResolvedFile} from '../utils/resolveDropEntries';
 
 interface UploadProgress {
@@ -29,6 +30,8 @@ const CHUNK_SIZE = 8 * 1024 * 1024;
 export const ObjectBrowserPage = () => {
 	const {bucket} = useParams<{bucket: string}>();
 	const [searchParams, setSearchParams] = useSearchParams();
+	const navigate = useNavigate();
+	const {isMobile} = useMobile();
 
 	const prefix = searchParams.get('prefix') ?? '';
 	const selectedKey = searchParams.get('key') ?? null;
@@ -281,6 +284,40 @@ export const ObjectBrowserPage = () => {
 
 	const showInspector = selectedKey !== null;
 
+	const browserProps = {
+		bucket,
+		prefix,
+		objects,
+		totalCount,
+		loading,
+		page,
+		pageSize,
+		selectedKey,
+		uploadProgress,
+		isDragging,
+		dragProps,
+		onNavigate: navigateTo,
+		onSelectObject: selectObject,
+		onPageChange: handlePageChange,
+		onPageSizeChange: handlePageSizeChange,
+		onUploadClick: () => {
+			fileInputRef.current?.click();
+		},
+		onFolderUploadClick: () => {
+			folderInputRef.current?.click();
+		},
+		onDownloadFolder: handleDownloadFolder,
+		onDeleteFolder: handleDeleteFolder,
+		folderSizes,
+		calculatingFolders,
+		onCalculateFolderSize: (p: string) => {
+			void calculateFolderSize(p);
+		},
+		onGoBack: () => {
+			void navigate('/');
+		},
+	};
+
 	return (
 		<div style={{display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden'}}>
 			{/* Hidden file inputs */}
@@ -308,8 +345,8 @@ export const ObjectBrowserPage = () => {
 				}}
 			/>
 
-			{/* Upload progress bar */}
-			{uploadProgress !== null && (
+			{/* Upload progress bar (desktop only — mobile shows it inline) */}
+			{uploadProgress !== null && !isMobile && (
 				<Stack
 					gap={4}
 					style={{
@@ -330,7 +367,7 @@ export const ObjectBrowserPage = () => {
 				</Stack>
 			)}
 
-			{/* When inspector is open and object is an image: full-attention mode */}
+			{/* When inspector is open and object is found: full-attention mode */}
 			{showInspector && selectedObject !== undefined ? (
 				<div
 					style={{
@@ -338,7 +375,7 @@ export const ObjectBrowserPage = () => {
 						top: 0,
 						right: 0,
 						bottom: 0,
-						left: 'var(--rail-width)',
+						left: isMobile ? 0 : 'var(--rail-width)',
 						zIndex: 10,
 						overflow: 'hidden',
 					}}
@@ -361,7 +398,7 @@ export const ObjectBrowserPage = () => {
 					/>
 				</div>
 			) : showInspector && selectedObject === undefined ? (
-				/* Key in URL but not yet in loaded objects — show browser alongside */
+				/* Key in URL but not yet in loaded objects — show browser */
 				<div style={{display: 'flex', flex: 1, minHeight: 0}}>
 					<div
 						style={{
@@ -371,36 +408,7 @@ export const ObjectBrowserPage = () => {
 							flexDirection: 'column',
 						}}
 					>
-						<ObjectBrowser
-							bucket={bucket}
-							prefix={prefix}
-							objects={objects}
-							totalCount={totalCount}
-							loading={loading}
-							page={page}
-							pageSize={pageSize}
-							selectedKey={selectedKey}
-							uploadProgress={uploadProgress}
-							isDragging={isDragging}
-							dragProps={dragProps}
-							onNavigate={navigateTo}
-							onSelectObject={selectObject}
-							onPageChange={handlePageChange}
-							onPageSizeChange={handlePageSizeChange}
-							onUploadClick={() => {
-								fileInputRef.current?.click();
-							}}
-							onFolderUploadClick={() => {
-								folderInputRef.current?.click();
-							}}
-							onDownloadFolder={handleDownloadFolder}
-							onDeleteFolder={handleDeleteFolder}
-							folderSizes={folderSizes}
-							calculatingFolders={calculatingFolders}
-							onCalculateFolderSize={(p) => {
-								void calculateFolderSize(p);
-							}}
-						/>
+						<ObjectBrowser {...browserProps} />
 					</div>
 				</div>
 			) : (
@@ -408,36 +416,7 @@ export const ObjectBrowserPage = () => {
 				<div
 					style={{flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column'}}
 				>
-					<ObjectBrowser
-						bucket={bucket}
-						prefix={prefix}
-						objects={objects}
-						totalCount={totalCount}
-						loading={loading}
-						page={page}
-						pageSize={pageSize}
-						selectedKey={selectedKey}
-						uploadProgress={uploadProgress}
-						isDragging={isDragging}
-						dragProps={dragProps}
-						onNavigate={navigateTo}
-						onSelectObject={selectObject}
-						onPageChange={handlePageChange}
-						onPageSizeChange={handlePageSizeChange}
-						onUploadClick={() => {
-							fileInputRef.current?.click();
-						}}
-						onFolderUploadClick={() => {
-							folderInputRef.current?.click();
-						}}
-						onDownloadFolder={handleDownloadFolder}
-						onDeleteFolder={handleDeleteFolder}
-						folderSizes={folderSizes}
-						calculatingFolders={calculatingFolders}
-						onCalculateFolderSize={(p) => {
-							void calculateFolderSize(p);
-						}}
-					/>
+					<ObjectBrowser {...browserProps} />
 				</div>
 			)}
 		</div>


### PR DESCRIPTION
## Summary

- **MobileContext** — ResizeObserver on the app shell container, single 640px breakpoint, drawer open/close state shared via context
- **AppShell** — slide-out navigation drawer with scrim on mobile; desktop rail layout unchanged
- **BucketListPage** — mobile view with storage summary card and touch-friendly bucket rows
- **ObjectBrowser** — mobile header with smart back navigation (parent folder or buckets list), FOLDERS/FILES grouping, List/Grid toggle, sticky upload button
- **ObjectInspector** — full-screen mobile inspector with swipe image navigation, peek sheet (SIZE/TYPE/MODIFIED), sticky action bar (copy link, download, delete), delete confirm step
- **22 new responsive tests** covering all mobile flows (drawer, navigation, file tap, inspector, delete confirm, image siblings)

## Test plan

- [ ] All 166 frontend tests pass (`bun run test`)
- [ ] Typecheck clean (`bun run typecheck`)
- [ ] Viewport ≤ 640px: hamburger renders, drawer opens/closes, bucket rows visible
- [ ] Tap bucket → mobile object browser with back arrow
- [ ] Back arrow from subfolder navigates to parent folder, not buckets list
- [ ] Tap file → full-screen inspector with peek sheet and action bar
- [ ] Delete shows confirm step before firing
- [ ] Swipe left/right navigates between images
- [ ] Viewport ≥ 641px: desktop layout unchanged

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)